### PR TITLE
[lowering] Bridge closure bundle ABI ({__fn, __env})

### DIFF
--- a/src/GRAM/__tests__/__snapshots__/bridge.test.ts.snap
+++ b/src/GRAM/__tests__/__snapshots__/bridge.test.ts.snap
@@ -5,10 +5,10 @@ exports[`GRAM Bridge: PAP — partial application objects > snapshot: $add 1 —
   fn main entry=entry
     entry:
       let v0 = 1
-      let env_pap1 = alloc { v0: v0 }
-      let fnref_pap1 = &pap_fn1
-      let closure_pap1 = alloc { __fn: fnref_pap1, __env: env_pap1 }
-      return closure_pap1
+      let env_cls1 = alloc { v0: v0 }
+      let fnref_cls1 = &pap_fn1
+      let closure_cls1 = alloc { __fn: fnref_cls1, __env: env_cls1 }
+      return closure_cls1
   fn pap_fn1(env2, arg3) entry=pap_fn1_entry
     pap_fn1_entry:
       let cap_0 = read env2.v0
@@ -39,13 +39,17 @@ exports[`GRAM Bridge: Phase 2 — closures and primops > (λx. x) 42 — identit
 "module
   fn main entry=entry
     entry:
-      let v0 = &closure_8
-      let v1 = 42
-      let v2 = call *v0(v1)
-      return v2
-  fn closure_8(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_8
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      let v3 = 42
+      let fnref4 = read closure_cls2.__fn
+      let env5 = read closure_cls2.__env
+      let v6 = call *fnref4(env5, v3)
+      return v6
+  fn closure_8(env0, x1) entry=entry
     entry:
-      return x"
+      return x1"
 `;
 
 exports[`GRAM Bridge: Phase 2 — closures and primops > snapshot: add(1, 2) 1`] = `
@@ -62,15 +66,19 @@ exports[`GRAM Bridge: Phase 3 — pattern matching > snapshot: match 0 / _ 1`] =
 "module
   fn main entry=entry
     entry:
-      let v0 = &closure_18
-      let v1 = 5
-      let v2 = call *v0(v1)
-      return v2
-  fn closure_18(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_18
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      let v3 = 5
+      let fnref4 = read closure_cls2.__fn
+      let env5 = read closure_cls2.__env
+      let v6 = call *fnref4(env5, v3)
+      return v6
+  fn closure_18(env0, x1) entry=entry
     entry:
       jump sw1
     sw1:
-      branch x { 0 -> case3; default -> default4 }
+      branch x1 { 0 -> case3; default -> default4 }
     case3:
       let v4 = 1
       let match0 = v4

--- a/src/GRAM/bridge/bundle.ts
+++ b/src/GRAM/bridge/bundle.ts
@@ -1,0 +1,54 @@
+import { Constructors } from "../../lowering/mir";
+import type * as MIR from "../../lowering/mir";
+import type { Ctx } from "./context";
+import * as C from "./context";
+
+const { Instr, Expr } = Constructors;
+
+export type Bundle = { readonly instrs: ReadonlyArray<MIR.Instr>; readonly closureRef: string };
+
+export const unpackEnv = (count: number, envParam: string): { vars: ReadonlyArray<string>; instrs: ReadonlyArray<MIR.Instr> } =>
+	Array(count)
+		.fill(0)
+		.reduce<{ vars: ReadonlyArray<string>; instrs: ReadonlyArray<MIR.Instr> }>(
+			(acc, _, j) => {
+				const v = `cap_${j}`;
+				return {
+					vars: [...acc.vars, v],
+					instrs: [...acc.instrs, Instr.Read(`v${j}`, envParam, v)],
+				};
+			},
+			{ vars: [], instrs: [] },
+		);
+
+export const bundleClosure = (fnName: string, captured: ReadonlyArray<string>, prefix: string): Bundle => {
+	const envRef = `env_${prefix}`;
+	const fnRef = `fnref_${prefix}`;
+	const closureRef = `closure_${prefix}`;
+
+	return {
+		instrs: [
+			Instr.Alloc({ type: "Record", fields: captured.map((a, i) => ({ label: `v${i}`, value: a })) }, envRef),
+			Instr.Let(fnRef, Expr.FuncRef(fnName)),
+			Instr.Alloc(
+				{
+					type: "Record",
+					fields: [
+						{ label: "__fn", value: fnRef },
+						{ label: "__env", value: envRef },
+					],
+				},
+				closureRef,
+			),
+		],
+		closureRef,
+	};
+};
+
+export const emitAtSite = (fnName: string, captured: ReadonlyArray<string>, ctx: Ctx, bindId?: number): [string, Ctx] => {
+	const [prefix, c1] = C.name(ctx, "cls");
+	const bundle = bundleClosure(fnName, captured, prefix);
+	const c2 = bundle.instrs.reduce((acc, i) => C.instr(acc, i), c1);
+	const c3 = bindId !== undefined ? C.bind(c2, bindId, bundle.closureRef) : c2;
+	return [bundle.closureRef, c3];
+};

--- a/src/GRAM/bridge/bundle.ts
+++ b/src/GRAM/bridge/bundle.ts
@@ -5,50 +5,43 @@ import * as C from "./context";
 
 const { Instr, Expr } = Constructors;
 
-export type Bundle = { readonly instrs: ReadonlyArray<MIR.Instr>; readonly closureRef: string };
+export type Packed = { readonly instrs: ReadonlyArray<MIR.Instr>; readonly ref: string };
 
-export const unpackEnv = (count: number, envParam: string): { vars: ReadonlyArray<string>; instrs: ReadonlyArray<MIR.Instr> } =>
-	Array(count)
-		.fill(0)
-		.reduce<{ vars: ReadonlyArray<string>; instrs: ReadonlyArray<MIR.Instr> }>(
-			(acc, _, j) => {
-				const v = `cap_${j}`;
-				return {
-					vars: [...acc.vars, v],
-					instrs: [...acc.instrs, Instr.Read(`v${j}`, envParam, v)],
-				};
-			},
-			{ vars: [], instrs: [] },
-		);
+export const read = (count: number, env: string): { vars: ReadonlyArray<string>; instrs: ReadonlyArray<MIR.Instr> } => {
+	const pairs = Array.from({ length: count }, (_, j) => {
+		const v = `cap_${j}`;
+		return { v, instr: Instr.Read(`v${j}`, env, v) };
+	});
+	return { vars: pairs.map(p => p.v), instrs: pairs.map(p => p.instr) };
+};
 
-export const bundleClosure = (fnName: string, captured: ReadonlyArray<string>, prefix: string): Bundle => {
-	const envRef = `env_${prefix}`;
-	const fnRef = `fnref_${prefix}`;
-	const closureRef = `closure_${prefix}`;
-
+export const bundle = (fn: string, captured: ReadonlyArray<string>, prefix: string): Packed => {
+	const env = `env_${prefix}`;
+	const fnref = `fnref_${prefix}`;
+	const ref = `closure_${prefix}`;
 	return {
 		instrs: [
-			Instr.Alloc({ type: "Record", fields: captured.map((a, i) => ({ label: `v${i}`, value: a })) }, envRef),
-			Instr.Let(fnRef, Expr.FuncRef(fnName)),
+			Instr.Alloc({ type: "Record", fields: captured.map((a, i) => ({ label: `v${i}`, value: a })) }, env),
+			Instr.Let(fnref, Expr.FuncRef(fn)),
 			Instr.Alloc(
 				{
 					type: "Record",
 					fields: [
-						{ label: "__fn", value: fnRef },
-						{ label: "__env", value: envRef },
+						{ label: "__fn", value: fnref },
+						{ label: "__env", value: env },
 					],
 				},
-				closureRef,
+				ref,
 			),
 		],
-		closureRef,
+		ref,
 	};
 };
 
-export const emitAtSite = (fnName: string, captured: ReadonlyArray<string>, ctx: Ctx, bindId?: number): [string, Ctx] => {
+export const emit = (fn: string, captured: ReadonlyArray<string>, ctx: Ctx, id?: number): [string, Ctx] => {
 	const [prefix, c1] = C.name(ctx, "cls");
-	const bundle = bundleClosure(fnName, captured, prefix);
-	const c2 = bundle.instrs.reduce((acc, i) => C.instr(acc, i), c1);
-	const c3 = bindId !== undefined ? C.bind(c2, bindId, bundle.closureRef) : c2;
-	return [bundle.closureRef, c3];
+	const packed = bundle(fn, captured, prefix);
+	const c2 = packed.instrs.reduce((acc, i) => C.instr(acc, i), c1);
+	const c3 = id !== undefined ? C.bind(c2, id, packed.ref) : c2;
+	return [packed.ref, c3];
 };

--- a/src/GRAM/bridge/closures.ts
+++ b/src/GRAM/bridge/closures.ts
@@ -4,7 +4,7 @@ import { Labels } from "../vocabulary";
 import { Constructors } from "../../lowering/mir";
 import type { Ctx } from "./context";
 import * as C from "./context";
-import * as Bundle from "./bundle";
+import * as Closure from "./bundle";
 
 const { Terminator, Block, Function: Fn } = Constructors;
 
@@ -21,7 +21,7 @@ export const closure = (id: NodeId, walk: (id: NodeId, ctx: Ctx) => [string, Ctx
 
 	const [envParam, c0] = C.name(ctx, "env");
 	const [formalParam, c1] = C.name(c0, formal);
-	const { vars: capVars, instrs: envReads } = Bundle.unpackEnv(captures.length, envParam);
+	const { vars: capVars, instrs: envReads } = Closure.read(captures.length, envParam);
 
 	const bodyCtx = captures.reduce(
 		(c, cap, i) => {
@@ -46,7 +46,7 @@ export const closure = (id: NodeId, walk: (id: NodeId, ctx: Ctx) => [string, Ctx
 	const withFn = C.func(withNested, fn);
 
 	const capturedValues = captures.map(cap => C.resolve(ctx, cap.target) ?? cap.name);
-	return Bundle.emitAtSite(funcName, capturedValues, withFn, id);
+	return Closure.emit(funcName, capturedValues, withFn, id);
 };
 
 type Capture = { readonly name: string; readonly target: NodeId };

--- a/src/GRAM/bridge/closures.ts
+++ b/src/GRAM/bridge/closures.ts
@@ -1,16 +1,14 @@
-import { Nodes, Edges, Query } from "../graph";
+import { Nodes, Edges } from "../graph";
 import type { NodeId } from "../graph";
-import { Tags, Labels } from "../vocabulary";
+import { Labels } from "../vocabulary";
 import { Constructors } from "../../lowering/mir";
-import type * as MIR from "../../lowering/mir";
 import type { Ctx } from "./context";
 import * as C from "./context";
+import * as Bundle from "./bundle";
 
-const { Terminator, Block, Function: Fn, Instr, Expr } = Constructors;
+const { Terminator, Block, Function: Fn } = Constructors;
 
-// Closure → MIR.Function + FuncRef at use site
-// The closure node wraps a lambda; the env holds captures.
-// We emit a function whose params = [env captures..., lambda param].
+// Closure → MIR.Function(env, formal) + { __fn, __env } bundle at the use site.
 export const closure = (id: NodeId, walk: (id: NodeId, ctx: Ctx) => [string, Ctx], ctx: Ctx): [string, Ctx] => {
 	const bodyEdge = Edges.one(id, Labels.BODY)(ctx.graph);
 	const envEdge = Edges.one(id, Labels.ENV)(ctx.graph);
@@ -18,37 +16,37 @@ export const closure = (id: NodeId, walk: (id: NodeId, ctx: Ctx) => [string, Ctx
 	const envId = envEdge?.target;
 	const lamNode = lamId !== undefined ? Nodes.get(lamId)(ctx.graph) : undefined;
 	const funcName = `closure_${id}`;
-	const paramName = (lamNode?.payload.variable ?? "arg") as string;
+	const formal = (lamNode?.payload.variable ?? "arg") as string;
 	const captures = envId !== undefined ? captureParams(envId, ctx) : [];
-	const allParams = [...captures.map(c => c.name), paramName];
 
-	// Build function body in a fresh context
-	const inner = C.fresh(ctx.graph);
-	const bound = captures.reduce<Ctx>((c, cap) => C.bind(c, cap.target, cap.name), inner);
-	const withLam = lamId !== undefined ? C.bind(bound, lamId, paramName) : bound;
+	const [envParam, c0] = C.name(ctx, "env");
+	const [formalParam, c1] = C.name(c0, formal);
+	const { vars: capVars, instrs: envReads } = Bundle.unpackEnv(captures.length, envParam);
+
+	const bodyCtx = captures.reduce(
+		(c, cap, i) => {
+			const v = capVars[i];
+			return v !== undefined ? C.bind(c, cap.target, v) : c;
+		},
+		C.bind(C.fork(ctx), lamId ?? -1, formalParam),
+	);
+
 	const lamBody = lamId !== undefined ? Edges.one(lamId, Labels.BODY)(ctx.graph) : undefined;
-	const [result, final] = lamBody !== undefined ? walk(lamBody.target, withLam) : C.name(withLam);
-	const [instrs, flushed] = C.flush(final);
+	const [bodyResult, final] = lamBody !== undefined ? walk(lamBody.target, bodyCtx) : C.name(bodyCtx);
+	const [bodyInstrs, flushed] = C.flush(final);
+
 	const entryBlock =
 		flushed.blocks.length > 0
-			? Block("entry", [], [...instrs], Terminator.Jump(flushed.blocks[0].label, []))
-			: Block("entry", [], [...instrs], Terminator.Return(result));
-	const fn = Fn(funcName, allParams, "entry", [entryBlock, ...flushed.blocks]);
+			? Block("entry", [], [...envReads, ...bodyInstrs], Terminator.Jump(flushed.blocks[0].label, []))
+			: Block("entry", [], [...envReads, ...bodyInstrs], Terminator.Return(bodyResult));
 
-	// Detect curried returns: if the body returns a FuncRef to a nested closure
-	// that has captures from this scope, a bare FuncRef is insufficient — the
-	// captures need to be bundled into a runtime closure struct.
-	const nestedWithCaptures = flushed.functions.filter(f => f.params.some(p => allParams.includes(p)));
-	if (nestedWithCaptures.length > 0) {
-		throw new Error("Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures");
-	}
+	const fn = Fn(funcName, [envParam, formalParam], "entry", [entryBlock, ...flushed.blocks]);
 
-	// Register function + any nested functions from body, emit FuncRef at use site
-	const withNested = flushed.functions.reduce<Ctx>((c, f) => C.func(c, f), ctx);
-	const c1 = C.func(withNested, fn);
-	const [ref, c2] = C.name(c1);
-	const c3 = C.instr(c2, Instr.Let(ref, Expr.FuncRef(funcName)));
-	return [ref, C.bind(c3, id, ref)];
+	const withNested = flushed.functions.reduce<Ctx>((c, f) => C.func(c, f), c1);
+	const withFn = C.func(withNested, fn);
+
+	const capturedValues = captures.map(cap => C.resolve(ctx, cap.target) ?? cap.name);
+	return Bundle.emitAtSite(funcName, capturedValues, withFn, id);
 };
 
 type Capture = { readonly name: string; readonly target: NodeId };

--- a/src/GRAM/bridge/emit.ts
+++ b/src/GRAM/bridge/emit.ts
@@ -96,9 +96,13 @@ const application = (id: NodeId, ctx: Ctx): [string, Ctx] => {
 	const argEdge = Edges.one(id, Labels.ARG)(ctx.graph);
 	const [fn, c1] = funcEdge !== undefined ? walk(funcEdge.target, ctx) : C.name(ctx);
 	const [arg, c2] = argEdge !== undefined ? walk(argEdge.target, c1) : C.name(c1);
-	const [result, c3] = C.name(c2);
-	const c4 = C.instr(c3, Constructors.Instr.Call({ type: "indirect", callee: fn }, [arg], result));
-	return [result, C.bind(c4, id, result)];
+	const [fnRef, c3] = C.name(c2, "fnref");
+	const [envRef, c4] = C.name(c3, "env");
+	const [result, c5] = C.name(c4);
+	const c6 = C.instr(c5, Constructors.Instr.Read("__fn", fn, fnRef));
+	const c7 = C.instr(c6, Constructors.Instr.Read("__env", fn, envRef));
+	const c8 = C.instr(c7, Constructors.Instr.Call({ type: "indirect", callee: fnRef }, [envRef, arg], result));
+	return [result, C.bind(c8, id, result)];
 };
 
 const letNode = (id: NodeId, ctx: Ctx): [string, Ctx] => {

--- a/src/GRAM/bridge/pap.ts
+++ b/src/GRAM/bridge/pap.ts
@@ -5,7 +5,7 @@ import { Constructors } from "../../lowering/mir";
 import type * as MIR from "../../lowering/mir";
 import type { Ctx } from "./context";
 import * as C from "./context";
-import * as Bundle from "./bundle";
+import * as Closure from "./bundle";
 import { ARITIES } from "../../lowering/shared/primops";
 
 const { Terminator, Block, Function: Fn, Instr, Expr } = Constructors;
@@ -53,7 +53,7 @@ export const pap = (id: NodeId, walk: (id: NodeId, ctx: Ctx) => [string, Ctx], c
 	const wrappers = buildWrappers(remaining, c1);
 	const c2 = emitWrapperFunctions(callee, arity, capturedNames.length, remaining, isPrimop, wrappers, c1);
 
-	return Bundle.emitAtSite(wrappers[0]?.fnName ?? "pap_fn", capturedNames, c2);
+	return Closure.emit(wrappers[0]?.fnName ?? "pap_fn", capturedNames, c2);
 };
 
 type Wrapper = { readonly fnName: string; readonly envParam: string; readonly freshParam: string };
@@ -88,7 +88,7 @@ const emitWrapperFunctions = (
 	}, ctx);
 
 const buildInvokeWrapper = (callee: string, arity: number, w: Wrapper, numCaptured: number, isPrimop: boolean): MIR.Function => {
-	const reads = Bundle.unpackEnv(numCaptured, w.envParam);
+	const reads = Closure.read(numCaptured, w.envParam);
 	const allArgs = [...reads.vars, w.freshParam];
 	const result = `result_${w.fnName}`;
 
@@ -100,12 +100,12 @@ const buildInvokeWrapper = (callee: string, arity: number, w: Wrapper, numCaptur
 };
 
 const buildCurryWrapper = (w: Wrapper, numCaptured: number, nextFnName: string): MIR.Function => {
-	const reads = Bundle.unpackEnv(numCaptured, w.envParam);
+	const reads = Closure.read(numCaptured, w.envParam);
 	const allArgs = [...reads.vars, w.freshParam];
 
-	const bundle = Bundle.bundleClosure(nextFnName, allArgs, w.fnName);
+	const packed = Closure.bundle(nextFnName, allArgs, w.fnName);
 
-	const block = Block(`${w.fnName}_entry`, [], [...reads.instrs, ...bundle.instrs], Terminator.Return(bundle.closureRef));
+	const block = Block(`${w.fnName}_entry`, [], [...reads.instrs, ...packed.instrs], Terminator.Return(packed.ref));
 
 	return Fn(w.fnName, [w.envParam, w.freshParam], block.label, [block]);
 };

--- a/src/GRAM/bridge/pap.ts
+++ b/src/GRAM/bridge/pap.ts
@@ -5,6 +5,7 @@ import { Constructors } from "../../lowering/mir";
 import type * as MIR from "../../lowering/mir";
 import type { Ctx } from "./context";
 import * as C from "./context";
+import * as Bundle from "./bundle";
 import { ARITIES } from "../../lowering/shared/primops";
 
 const { Terminator, Block, Function: Fn, Instr, Expr } = Constructors;
@@ -52,7 +53,7 @@ export const pap = (id: NodeId, walk: (id: NodeId, ctx: Ctx) => [string, Ctx], c
 	const wrappers = buildWrappers(remaining, c1);
 	const c2 = emitWrapperFunctions(callee, arity, capturedNames.length, remaining, isPrimop, wrappers, c1);
 
-	return emitClosureBundle(wrappers[0]?.fnName ?? "pap_fn", capturedNames, c2);
+	return Bundle.emitAtSite(wrappers[0]?.fnName ?? "pap_fn", capturedNames, c2);
 };
 
 type Wrapper = { readonly fnName: string; readonly envParam: string; readonly freshParam: string };
@@ -87,7 +88,7 @@ const emitWrapperFunctions = (
 	}, ctx);
 
 const buildInvokeWrapper = (callee: string, arity: number, w: Wrapper, numCaptured: number, isPrimop: boolean): MIR.Function => {
-	const reads = unpackEnv(numCaptured, w.envParam);
+	const reads = Bundle.unpackEnv(numCaptured, w.envParam);
 	const allArgs = [...reads.vars, w.freshParam];
 	const result = `result_${w.fnName}`;
 
@@ -99,57 +100,12 @@ const buildInvokeWrapper = (callee: string, arity: number, w: Wrapper, numCaptur
 };
 
 const buildCurryWrapper = (w: Wrapper, numCaptured: number, nextFnName: string): MIR.Function => {
-	const reads = unpackEnv(numCaptured, w.envParam);
+	const reads = Bundle.unpackEnv(numCaptured, w.envParam);
 	const allArgs = [...reads.vars, w.freshParam];
 
-	const bundle = bundleClosure(nextFnName, allArgs, w.fnName);
+	const bundle = Bundle.bundleClosure(nextFnName, allArgs, w.fnName);
 
 	const block = Block(`${w.fnName}_entry`, [], [...reads.instrs, ...bundle.instrs], Terminator.Return(bundle.closureRef));
 
 	return Fn(w.fnName, [w.envParam, w.freshParam], block.label, [block]);
-};
-
-const unpackEnv = (count: number, envParam: string): { vars: ReadonlyArray<string>; instrs: ReadonlyArray<MIR.Instr> } =>
-	Array(count)
-		.fill(0)
-		.reduce<{ vars: ReadonlyArray<string>; instrs: ReadonlyArray<MIR.Instr> }>(
-			(acc, _, j) => {
-				const v = `cap_${j}`;
-				return {
-					vars: [...acc.vars, v],
-					instrs: [...acc.instrs, Instr.Read(`v${j}`, envParam, v)],
-				};
-			},
-			{ vars: [], instrs: [] },
-		);
-
-const bundleClosure = (fnName: string, captured: ReadonlyArray<string>, prefix: string): { instrs: ReadonlyArray<MIR.Instr>; closureRef: string } => {
-	const envRef = `env_${prefix}`;
-	const fnRef = `fnref_${prefix}`;
-	const closureRef = `closure_${prefix}`;
-
-	return {
-		instrs: [
-			Instr.Alloc({ type: "Record", fields: captured.map((a, i) => ({ label: `v${i}`, value: a })) }, envRef),
-			Instr.Let(fnRef, Expr.FuncRef(fnName)),
-			Instr.Alloc(
-				{
-					type: "Record",
-					fields: [
-						{ label: "__fn", value: fnRef },
-						{ label: "__env", value: envRef },
-					],
-				},
-				closureRef,
-			),
-		],
-		closureRef,
-	};
-};
-
-const emitClosureBundle = (outerFnName: string, capturedNames: ReadonlyArray<string>, ctx: Ctx): [string, Ctx] => {
-	const [prefix, c1] = C.name(ctx, "pap");
-	const bundle = bundleClosure(outerFnName, capturedNames, prefix);
-	const c2 = bundle.instrs.reduce((c, i) => C.instr(c, i), c1);
-	return [bundle.closureRef, C.bind(c2, -1, bundle.closureRef)];
 };

--- a/src/__tests__/integration/__snapshots__/dependent-types.test.ts.snap
+++ b/src/__tests__/integration/__snapshots__/dependent-types.test.ts.snap
@@ -4,35 +4,45 @@ exports[`Language Tour — Dependent Types > dependent functions 1`] = `
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_19;
-  return v0;
+  const env_cls2 = {
+    v0: Num,
+    v1: String
+  };
+  const fnref_cls2 = closure_19;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_19(Num, String, b) {
+function closure_19(env0, b1) {
   let __block = "entry";
   while (true) {
     switch (__block) {
       case "entry": {
+        const cap_0 = env0.v0;
+        const cap_1 = env0.v1;
         (__block = "sw1");
         break;
       }
       case "sw1": {
-        if ((String(b) === "true")) {
+        if ((String(b1) === "true")) {
           (__block = "case3");
           break;
         }
-        if ((String(b) === "false")) {
+        if ((String(b1) === "false")) {
           (__block = "case4");
           break;
         }
       }
       case "case3": {
-        const match0 = Num;
+        const match0 = cap_0;
         (__block = "join2");
         break;
       }
       case "case4": {
-        const match0 = String;
+        const match0 = cap_1;
         (__block = "join2");
         break;
       }
@@ -100,18 +110,22 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_19
-      return v0
-  fn closure_19(Num, String, b) entry=entry
+      let env_cls2 = alloc { v0: Num, v1: String }
+      let fnref_cls2 = &closure_19
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_19(env0, b1) entry=entry
     entry:
+      let cap_0 = read env0.v0
+      let cap_1 = read env0.v1
       jump sw1
     sw1:
-      branch b { true -> case3 | false -> case4 }
+      branch b1 { true -> case3 | false -> case4 }
     case3:
-      let match0 = Num
+      let match0 = cap_0
       jump join2
     case4:
-      let match0 = String
+      let match0 = cap_1
       jump join2
     join2:
       return match0",
@@ -160,8 +174,10 @@ return main();
     "codegenJS": "function main() {
   const v0 = makeType;
   const v1 = true;
-  const v2 = v0(v1);
-  return v2;
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  return v4;
 }
 return main();
 ",
@@ -184,8 +200,10 @@ return main();
     entry:
       let v0 = makeType
       let v1 = true
-      let v2 = call *v0(v1)
-      return v2",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      return v4",
     "name": "T1",
     "normalized": "Num",
     "solverTrace": "=== Formula ===
@@ -220,8 +238,10 @@ return main();
     "codegenJS": "function main() {
   const v0 = makeType;
   const v1 = false;
-  const v2 = v0(v1);
-  return v2;
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  return v4;
 }
 return main();
 ",
@@ -244,8 +264,10 @@ return main();
     entry:
       let v0 = makeType
       let v1 = false
-      let v2 = call *v0(v1)
-      return v2",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      return v4",
     "name": "T2",
     "normalized": "String",
     "solverTrace": "=== Formula ===
@@ -503,11 +525,38 @@ return main();
 exports[`Language Tour — Dependent Types > generic dependent pairs 1`] = `
 [
   {
-    "codegenJS": "",
+    "codegenJS": "function main() {
+  const env_cls2 = {};
+  const fnref_cls2 = closure_28;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_29(env0, p1) {
+  const cap_0 = env0.v0;
+  const v0 = {};
+  return v0;
+}
+
+function closure_28(env0, a1) {
+  const env_cls2 = {
+    v0: a1
+  };
+  const fnref_cls2 = closure_29;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+return main();
+",
     "elaborated": "λ(a: Type) ->
   λ(p: Π(t1: a) -> Type) ->
     Σ($sig: [ snd: p :fst, fst: a ]) . Schema [ snd: p :fst, fst: a ]",
-    "error": "Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures",
     "gram": "[1] root
   :entry -> [3]
 [2] stmt:let {"variable":"Pair"}
@@ -590,7 +639,24 @@ exports[`Language Tour — Dependent Types > generic dependent pairs 1`] = `
   :env -> [27]",
     "ivl": "true",
     "kind": "let",
-    "mir": "",
+    "mir": "module
+  fn main entry=entry
+    entry:
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_28
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_29(env0, p1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let v0 = alloc {  }
+      return v0
+  fn closure_28(env0, a1) entry=entry
+    entry:
+      let env_cls2 = alloc { v0: a1 }
+      let fnref_cls2 = &closure_29
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "Pair",
     "normalized": "λ(a: Type) ->
   (closure: λ(p: Π(t1: a) -> Type) ->

--- a/src/__tests__/integration/__snapshots__/ffi.test.ts.snap
+++ b/src/__tests__/integration/__snapshots__/ffi.test.ts.snap
@@ -12,13 +12,18 @@ exports[`Language Tour — Foreign Function Interface > basic FFI 1`] = `
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_20;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_20;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_20(name) {
+function closure_20(env0, name1) {
   const v0 = "Hello, ";
-  const v1 = (v0 + name);
+  const v1 = (v0 + name1);
   const v2 = print(v1);
   const v3 = null;
   return v3;
@@ -64,12 +69,14 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_20
-      return v0
-  fn closure_20(name) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_20
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_20(env0, name1) entry=entry
     entry:
       let v0 = "Hello, "
-      let v1 = ++(v0, name)
+      let v1 = ++(v0, name1)
       let v2 = call print(v1)
       let v3 = unit
       return v3",

--- a/src/__tests__/integration/__snapshots__/functions.test.ts.snap
+++ b/src/__tests__/integration/__snapshots__/functions.test.ts.snap
@@ -4,12 +4,17 @@ exports[`Language Tour — Functions & Application > function application 1`] = 
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_7;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_7;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_7(x) {
-  return x;
+function closure_7(env0, x1) {
+  return x1;
 }
 return main();
 ",
@@ -35,11 +40,13 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_7
-      return v0
-  fn closure_7(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_7
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_7(env0, x1) entry=entry
     entry:
-      return x",
+      return x1",
     "name": "identity",
     "normalized": "λ(x: Num) -> (closure: x -| Γ: x)",
     "solverTrace": "=== Formula ===
@@ -155,8 +162,10 @@ return main();
     "codegenJS": "function main() {
   const v0 = identity;
   const v1 = 42;
-  const v2 = v0(v1);
-  return v2;
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  return v4;
 }
 return main();
 ",
@@ -179,8 +188,10 @@ return main();
     entry:
       let v0 = identity
       let v1 = 42
-      let v2 = call *v0(v1)
-      return v2",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      return v4",
     "name": "forty2",
     "normalized": "42",
     "solverTrace": "=== Formula ===
@@ -215,10 +226,14 @@ return main();
     "codegenJS": "function main() {
   const v0 = add;
   const v1 = 10;
-  const v2 = v0(v1);
-  const v3 = 20;
-  const v4 = v2(v3);
-  return v4;
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  const v5 = 20;
+  const fnref6 = v4.__fn;
+  const env7 = v4.__env;
+  const v8 = fnref6(env7, v5);
+  return v8;
 }
 return main();
 ",
@@ -245,10 +260,14 @@ return main();
     entry:
       let v0 = add
       let v1 = 10
-      let v2 = call *v0(v1)
-      let v3 = 20
-      let v4 = call *v2(v3)
-      return v4",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      let v5 = 20
+      let fnref6 = read v4.__fn
+      let env7 = read v4.__env
+      let v8 = call *fnref6(env7, v5)
+      return v8",
     "name": "added",
     "normalized": "30",
     "solverTrace": "=== Formula ===
@@ -285,9 +304,56 @@ return main();
 exports[`Language Tour — Functions & Application > higher-order functions 1`] = `
 [
   {
-    "codegenJS": "",
+    "codegenJS": "function main() {
+  const env_cls2 = {};
+  const fnref_cls2 = closure_21;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_23(env0, x1) {
+  const cap_0 = env0.v0;
+  const cap_1 = env0.v1;
+  const fnref0 = cap_1.__fn;
+  const env1 = cap_1.__env;
+  const v2 = fnref0(env1, x1);
+  const fnref3 = cap_0.__fn;
+  const env4 = cap_0.__env;
+  const v5 = fnref3(env4, v2);
+  return v5;
+}
+
+function closure_22(env0, g1) {
+  const cap_0 = env0.v0;
+  const env_cls2 = {
+    v0: cap_0,
+    v1: g1
+  };
+  const fnref_cls2 = closure_23;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_21(env0, f1) {
+  const env_cls2 = {
+    v0: f1
+  };
+  const fnref_cls2 = closure_22;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+return main();
+",
     "elaborated": "λ(f: Π(t2: Num) -> Num) -> λ(g: Π(t4: Num) -> Num) -> λ(x: Num) -> f (g x)",
-    "error": "Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures",
     "gram": "[1] root
   :entry -> [3]
 [2] stmt:let {"variable":"compose"}
@@ -355,7 +421,37 @@ exports[`Language Tour — Functions & Application > higher-order functions 1`] 
   :env -> [20]",
     "ivl": "(forall ((x Real)) (= x x))",
     "kind": "let",
-    "mir": "",
+    "mir": "module
+  fn main entry=entry
+    entry:
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_21
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_23(env0, x1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let cap_1 = read env0.v1
+      let fnref0 = read cap_1.__fn
+      let env1 = read cap_1.__env
+      let v2 = call *fnref0(env1, x1)
+      let fnref3 = read cap_0.__fn
+      let env4 = read cap_0.__env
+      let v5 = call *fnref3(env4, v2)
+      return v5
+  fn closure_22(env0, g1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let env_cls2 = alloc { v0: cap_0, v1: g1 }
+      let fnref_cls2 = &closure_23
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_21(env0, f1) entry=entry
+    entry:
+      let env_cls2 = alloc { v0: f1 }
+      let fnref_cls2 = &closure_22
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "compose",
     "normalized": "λ(f: Π(t2: Num) -> (closure: Num -| Γ: t2)) ->
   (closure: λ(g: Π(t4: Num) -> Num) -> λ(x: Num) -> f (g x) -| Γ: f)",
@@ -400,13 +496,18 @@ exports[`Language Tour — Functions & Application > higher-order functions 1`] 
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_13;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_13;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_13(x) {
+function closure_13(env0, x1) {
   const v0 = 1;
-  const v1 = (x + v0);
+  const v1 = (x1 + v0);
   return v1;
 }
 return main();
@@ -452,12 +553,14 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_13
-      return v0
-  fn closure_13(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_13
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_13(env0, x1) entry=entry
     entry:
       let v0 = 1
-      let v1 = +(x, v0)
+      let v1 = +(x1, v0)
       return v1",
     "name": "add1",
     "normalized": "λ(x: Num) -> (closure: FFI.$add x 1 -| Γ: x)",
@@ -518,13 +621,18 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_13;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_13;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_13(x) {
+function closure_13(env0, x1) {
   const v0 = 5;
-  const v1 = (x + v0);
+  const v1 = (x1 + v0);
   return v1;
 }
 return main();
@@ -570,12 +678,14 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_13
-      return v0
-  fn closure_13(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_13
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_13(env0, x1) entry=entry
     entry:
       let v0 = 5
-      let v1 = +(x, v0)
+      let v1 = +(x1, v0)
       return v1",
     "name": "add5",
     "normalized": "λ(x: Num) -> (closure: FFI.$add x 5 -| Γ: x)",
@@ -636,13 +746,18 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_13;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_13;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_13(x) {
+function closure_13(env0, x1) {
   const v0 = 2;
-  const v1 = (x * v0);
+  const v1 = (x1 * v0);
   return v1;
 }
 return main();
@@ -688,12 +803,14 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_13
-      return v0
-  fn closure_13(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_13
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_13(env0, x1) entry=entry
     entry:
       let v0 = 2
-      let v1 = *(x, v0)
+      let v1 = *(x1, v0)
       return v1",
     "name": "double",
     "normalized": "λ(x: Num) -> (closure: FFI.$mul x 2 -| Γ: x)",
@@ -756,10 +873,14 @@ return main();
     "codegenJS": "function main() {
   const v0 = compose;
   const v1 = double;
-  const v2 = v0(v1);
-  const v3 = add1;
-  const v4 = v2(v3);
-  return v4;
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  const v5 = add1;
+  const fnref6 = v4.__fn;
+  const env7 = v4.__env;
+  const v8 = fnref6(env7, v5);
+  return v8;
 }
 return main();
 ",
@@ -792,10 +913,14 @@ return main();
     entry:
       let v0 = compose
       let v1 = double
-      let v2 = call *v0(v1)
-      let v3 = add1
-      let v4 = call *v2(v3)
-      return v4",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      let v5 = add1
+      let fnref6 = read v4.__fn
+      let env7 = read v4.__env
+      let v8 = call *fnref6(env7, v5)
+      return v8",
     "name": "add1ThenDouble",
     "normalized": "λ(x: Num) -> (closure: f (g x) -| Γ: x; g; f; compose)",
     "solverTrace": "=== Formula ===
@@ -833,12 +958,17 @@ exports[`Language Tour — Functions & Application > lambda expressions 1`] = `
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_7;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_7;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_7(x) {
-  return x;
+function closure_7(env0, x1) {
+  return x1;
 }
 return main();
 ",
@@ -864,11 +994,13 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_7
-      return v0
-  fn closure_7(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_7
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_7(env0, x1) entry=entry
     entry:
-      return x",
+      return x1",
     "name": "identity",
     "normalized": "λ(x: Num) -> (closure: x -| Γ: x)",
     "solverTrace": "=== Formula ===
@@ -911,9 +1043,35 @@ return main();
     "validity": "valid",
   },
   {
-    "codegenJS": "",
+    "codegenJS": "function main() {
+  const env_cls2 = {};
+  const fnref_cls2 = closure_10;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_11(env0, y1) {
+  const cap_0 = env0.v0;
+  return cap_0;
+}
+
+function closure_10(env0, x1) {
+  const env_cls2 = {
+    v0: x1
+  };
+  const fnref_cls2 = closure_11;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+return main();
+",
     "elaborated": "λ(x: Num) -> λ(y: String) -> x",
-    "error": "Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures",
     "gram": "[1] root
   :entry -> [3]
 [2] stmt:let {"variable":"const"}
@@ -943,7 +1101,23 @@ return main();
   :env -> [9]",
     "ivl": "(forall ((x Real)) (forall ((y String)) (= x x)))",
     "kind": "let",
-    "mir": "",
+    "mir": "module
+  fn main entry=entry
+    entry:
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_10
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_11(env0, y1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      return cap_0
+  fn closure_10(env0, x1) entry=entry
+    entry:
+      let env_cls2 = alloc { v0: x1 }
+      let fnref_cls2 = &closure_11
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "const",
     "normalized": "λ(x: Num) -> (closure: λ(y: String) -> x -| Γ: x)",
     "solverTrace": "=== Formula ===
@@ -992,13 +1166,23 @@ exports[`Language Tour — Statement Blocks > block with local bindings 1`] = `
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_24;
-  return v0;
+  const env_cls2 = {
+    v0: doubled,
+    v1: added
+  };
+  const fnref_cls2 = closure_24;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_24(doubled, added, x) {
+function closure_24(env0, x1) {
+  const cap_0 = env0.v0;
+  const cap_1 = env0.v1;
   const v0 = 2;
-  const v1 = (x * v0);
+  const v1 = (x1 * v0);
   const doubled2 = v1;
   const v3 = 10;
   const v4 = (doubled2 + v3);
@@ -1108,12 +1292,16 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_24
-      return v0
-  fn closure_24(doubled, added, x) entry=entry
+      let env_cls2 = alloc { v0: doubled, v1: added }
+      let fnref_cls2 = &closure_24
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_24(env0, x1) entry=entry
     entry:
+      let cap_0 = read env0.v0
+      let cap_1 = read env0.v1
       let v0 = 2
-      let v1 = *(x, v0)
+      let v1 = *(x1, v0)
       let doubled2 = v1
       let v3 = 10
       let v4 = +(doubled2, v3)
@@ -1229,8 +1417,10 @@ return main();
     "codegenJS": "function main() {
   const v0 = compute;
   const v1 = 5;
-  const v2 = v0(v1);
-  return v2;
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  return v4;
 }
 return main();
 ",
@@ -1253,8 +1443,10 @@ return main();
     entry:
       let v0 = compute
       let v1 = 5
-      let v2 = call *v0(v1)
-      return v2",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      return v4",
     "name": "result",
     "normalized": "20",
     "solverTrace": "=== Formula ===
@@ -1300,15 +1492,23 @@ exports[`Language Tour — Statement Blocks > side effects in blocks 1`] = `
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_34;
-  return v0;
+  const env_cls2 = {
+    v0: result
+  };
+  const fnref_cls2 = closure_34;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_34(result, x) {
+function closure_34(env0, x1) {
+  const cap_0 = env0.v0;
   const v0 = "Computing...";
   const v1 = print(v0);
   const v2 = 2;
-  const v3 = (x * v2);
+  const v3 = (x1 * v2);
   const result4 = v3;
   const v6 = stringify(v5, result4);
   const v7 = print(v6);
@@ -1415,14 +1615,17 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_34
-      return v0
-  fn closure_34(result, x) entry=entry
+      let env_cls2 = alloc { v0: result }
+      let fnref_cls2 = &closure_34
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_34(env0, x1) entry=entry
     entry:
+      let cap_0 = read env0.v0
       let v0 = "Computing..."
       let v1 = call print(v0)
       let v2 = 2
-      let v3 = *(x, v2)
+      let v3 = *(x1, v2)
       let result4 = v3
       let v6 = call stringify(v5, result4)
       let v7 = call print(v6)

--- a/src/__tests__/integration/__snapshots__/higher-kinded.test.ts.snap
+++ b/src/__tests__/integration/__snapshots__/higher-kinded.test.ts.snap
@@ -113,11 +113,16 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_45;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_45;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_45(f) {
+function closure_45(env0, f1) {
   const v0 = {};
   return v0;
 }
@@ -303,9 +308,11 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_45
-      return v0
-  fn closure_45(f) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_45
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_45(env0, f1) entry=entry
     entry:
       let v0 = alloc {  }
       return v0",
@@ -768,7 +775,56 @@ return main();
     "validity": "valid",
   },
   {
-    "codegenJS": "",
+    "codegenJS": "function main() {
+  const env_cls2 = {
+    v0: cap0
+  };
+  const fnref_cls2 = closure_70;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_72(env0, a1) {
+  const cap_0 = env0.v0;
+  const cap_1 = env0.v1;
+  const cap_2 = env0.v2;
+  return cap_0;
+}
+
+function closure_71(env0, functor1) {
+  const cap_0 = env0.v0;
+  const cap_1 = env0.v1;
+  const env_cls2 = {
+    v0: cap_0,
+    v1: cap_1,
+    v2: functor1
+  };
+  const fnref_cls2 = closure_72;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_70(env0, f1) {
+  const cap_0 = env0.v0;
+  const env_cls2 = {
+    v0: cap_0,
+    v1: f1
+  };
+  const fnref_cls2 = closure_71;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+return main();
+",
     "elaborated": "λ(f: Π(t12: Type) -> Type) =>
   λ(functor: Σ($sig: [ map: Π(a: Type) =>
       Π(b: Type) => Π(t5: Π(t6: a) -> b) -> Π(t7: f a) -> f b ]) .
@@ -779,7 +835,6 @@ return main();
       λ(b: Type) =>
         λ(fn: Π(t14: a) -> b) ->
           λ(container: f a) -> ((functor).map) @a @b fn container",
-    "error": "Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures",
     "gram": "[1] root
   :entry -> [3]
 [2] stmt:let {"variable":"fmap"}
@@ -1026,7 +1081,34 @@ return main();
     (forall ((container App_Fn_Type_Type_Type))
       (and (= a a) (= b b) (= container container)))))",
     "kind": "let",
-    "mir": "",
+    "mir": "module
+  fn main entry=entry
+    entry:
+      let env_cls2 = alloc { v0: cap0 }
+      let fnref_cls2 = &closure_70
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_72(env0, a1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let cap_1 = read env0.v1
+      let cap_2 = read env0.v2
+      return cap_0
+  fn closure_71(env0, functor1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let cap_1 = read env0.v1
+      let env_cls2 = alloc { v0: cap_0, v1: cap_1, v2: functor1 }
+      let fnref_cls2 = &closure_72
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_70(env0, f1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let env_cls2 = alloc { v0: cap_0, v1: f1 }
+      let fnref_cls2 = &closure_71
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "fmap",
     "normalized": "λ(f: Π(t12: Type) -> (closure: Type -| Γ: t12)) =>
   (closure: λ(functor: Σ($sig: [ map: Π(a: Type) =>
@@ -1095,7 +1177,86 @@ return main();
     "name": "(using)",
   },
   {
-    "codegenJS": "",
+    "codegenJS": "function main() {
+  const env_cls2 = {
+    v0: fmap
+  };
+  const fnref_cls2 = closure_67;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function pap_fn13(env14, arg15) {
+  const cap_0 = env14.v0;
+  const result_pap_fn13 = stringify(cap_0, arg15);
+  return result_pap_fn13;
+}
+
+function closure_69(env0, A1) {
+  const cap_0 = env0.v0;
+  const cap_1 = env0.v1;
+  const cap_2 = env0.v2;
+  const fnref0 = cap_0.__fn;
+  const env1 = cap_0.__env;
+  const v2 = fnref0(env1, cap_1);
+  const fnref3 = v2.__fn;
+  const env4 = v2.__env;
+  const v5 = fnref3(env4, A1);
+  const fnref6 = v5.__fn;
+  const env7 = v5.__env;
+  const v8 = fnref6(env7, cap_2);
+  const v9 = "String";
+  const fnref10 = v8.__fn;
+  const env11 = v8.__env;
+  const v12 = fnref10(env11, v9);
+  const env_cls13 = {
+    v0: cap_2
+  };
+  const fnref_cls13 = pap_fn13;
+  const closure_cls13 = {
+    __fn: fnref_cls13,
+    __env: env_cls13
+  };
+  const fnref14 = v12.__fn;
+  const env15 = v12.__env;
+  const v16 = fnref14(env15, closure_cls13);
+  return v16;
+}
+
+function closure_68(env0, a1) {
+  const cap_0 = env0.v0;
+  const cap_1 = env0.v1;
+  const env_cls2 = {
+    v0: cap_1,
+    v1: cap_0,
+    v2: a1
+  };
+  const fnref_cls2 = closure_69;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_67(env0, F1) {
+  const cap_0 = env0.v0;
+  const env_cls2 = {
+    v0: F1,
+    v1: cap_0
+  };
+  const fnref_cls2 = closure_68;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+return main();
+",
     "elaborated": "λ(F: Π(t12: Type) -> Type) =>
   λ(a: Type) =>
     λ(A: Σ($sig: [ map: Π(a: Type) =>
@@ -1104,7 +1265,6 @@ return main();
         [ map: Π(a: Type) =>
             Π(b: Type) => Π(t5: Π(t6: a) -> b) -> Π(t7: F a) -> F b ]) =>
       fmap @F @A @a @String (FFI.stringify @a)",
-    "error": "Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures",
     "gram": "[1] root
   :entry -> [3]
 [2] stmt:let {"variable":"strmap"}
@@ -1365,7 +1525,58 @@ return main();
   :env -> [66]",
     "ivl": "(forall ((a Type)) (and (= a a) (= a a)))",
     "kind": "let",
-    "mir": "",
+    "mir": "module
+  fn main entry=entry
+    entry:
+      let env_cls2 = alloc { v0: fmap }
+      let fnref_cls2 = &closure_67
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn pap_fn13(env14, arg15) entry=pap_fn13_entry
+    pap_fn13_entry:
+      let cap_0 = read env14.v0
+      let result_pap_fn13 = call stringify(cap_0, arg15)
+      return result_pap_fn13
+  fn closure_69(env0, A1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let cap_1 = read env0.v1
+      let cap_2 = read env0.v2
+      let fnref0 = read cap_0.__fn
+      let env1 = read cap_0.__env
+      let v2 = call *fnref0(env1, cap_1)
+      let fnref3 = read v2.__fn
+      let env4 = read v2.__env
+      let v5 = call *fnref3(env4, A1)
+      let fnref6 = read v5.__fn
+      let env7 = read v5.__env
+      let v8 = call *fnref6(env7, cap_2)
+      let v9 = String
+      let fnref10 = read v8.__fn
+      let env11 = read v8.__env
+      let v12 = call *fnref10(env11, v9)
+      let env_cls13 = alloc { v0: cap_2 }
+      let fnref_cls13 = &pap_fn13
+      let closure_cls13 = alloc { __fn: fnref_cls13, __env: env_cls13 }
+      let fnref14 = read v12.__fn
+      let env15 = read v12.__env
+      let v16 = call *fnref14(env15, closure_cls13)
+      return v16
+  fn closure_68(env0, a1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let cap_1 = read env0.v1
+      let env_cls2 = alloc { v0: cap_1, v1: cap_0, v2: a1 }
+      let fnref_cls2 = &closure_69
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_67(env0, F1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let env_cls2 = alloc { v0: F1, v1: cap_0 }
+      let fnref_cls2 = &closure_68
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "strmap",
     "normalized": "λ(F: Π(t12: Type) -> (closure: Type -| Γ: t12)) =>
   (closure: λ(a: Type) =>
@@ -1516,14 +1727,22 @@ return main();
   {
     "codegenJS": "function main() {
   const v0 = strmap;
-  const v2 = v0(v1);
-  const v3 = "Num";
-  const v4 = v2(v3);
-  const v5 = ListFunctor;
-  const v6 = v4(v5);
-  const v7 = listOf1;
-  const v8 = v6(v7);
-  return v8;
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  const v5 = "Num";
+  const fnref6 = v4.__fn;
+  const env7 = v4.__env;
+  const v8 = fnref6(env7, v5);
+  const v9 = ListFunctor;
+  const fnref10 = v8.__fn;
+  const env11 = v8.__env;
+  const v12 = fnref10(env11, v9);
+  const v13 = listOf1;
+  const fnref14 = v12.__fn;
+  const env15 = v12.__env;
+  const v16 = fnref14(env15, v13);
+  return v16;
 }
 return main();
 ",
@@ -1621,14 +1840,22 @@ return main();
   fn main entry=entry
     entry:
       let v0 = strmap
-      let v2 = call *v0(v1)
-      let v3 = Num
-      let v4 = call *v2(v3)
-      let v5 = ListFunctor
-      let v6 = call *v4(v5)
-      let v7 = listOf1
-      let v8 = call *v6(v7)
-      return v8",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      let v5 = Num
+      let fnref6 = read v4.__fn
+      let env7 = read v4.__env
+      let v8 = call *fnref6(env7, v5)
+      let v9 = ListFunctor
+      let fnref10 = read v8.__fn
+      let env11 = read v8.__env
+      let v12 = call *fnref10(env11, v9)
+      let v13 = listOf1
+      let fnref14 = read v12.__fn
+      let env15 = read v12.__env
+      let v16 = call *fnref14(env15, v13)
+      return v16",
     "name": "strList",
     "normalized": "Struct [ cons: Struct [ 0: (stringify: (Num) (1)), 1: Struct [ nil: unit ] ] ]",
     "solverTrace": "=== Formula ===
@@ -1771,11 +1998,16 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_45;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_45;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_45(f) {
+function closure_45(env0, f1) {
   const v0 = {};
   return v0;
 }
@@ -1961,9 +2193,11 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_45
-      return v0
-  fn closure_45(f) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_45
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_45(env0, f1) entry=entry
     entry:
       let v0 = alloc {  }
       return v0",

--- a/src/__tests__/integration/__snapshots__/polymorphism.test.ts.snap
+++ b/src/__tests__/integration/__snapshots__/polymorphism.test.ts.snap
@@ -4,17 +4,27 @@ exports[`Language Tour — Polymorphism > forcing implicits 1`] = `
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_10;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_10;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_11(x) {
-  return x;
+function closure_11(env0, x1) {
+  return x1;
 }
 
-function closure_10(a) {
-  const v0 = closure_11;
-  return v0;
+function closure_10(env0, a1) {
+  const env_cls2 = {};
+  const fnref_cls2 = closure_11;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 return main();
 ",
@@ -53,15 +63,19 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_10
-      return v0
-  fn closure_11(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_10
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_11(env0, x1) entry=entry
     entry:
-      return x
-  fn closure_10(a) entry=entry
+      return x1
+  fn closure_10(env0, a1) entry=entry
     entry:
-      let v0 = &closure_11
-      return v0",
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_11
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "id",
     "normalized": "λ(a: Type) => (closure: λ(x: a) -> x -| Γ: a)",
     "solverTrace": "=== Formula ===
@@ -108,10 +122,14 @@ return main();
     "codegenJS": "function main() {
   const v0 = id;
   const v1 = String;
-  const v2 = v0(v1);
-  const v3 = "hello";
-  const v4 = v2(v3);
-  return v4;
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  const v5 = "hello";
+  const fnref6 = v4.__fn;
+  const env7 = v4.__env;
+  const v8 = fnref6(env7, v5);
+  return v8;
 }
 return main();
 ",
@@ -141,10 +159,14 @@ return main();
     entry:
       let v0 = id
       let v1 = String
-      let v2 = call *v0(v1)
-      let v3 = "hello"
-      let v4 = call *v2(v3)
-      return v4",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      let v5 = "hello"
+      let fnref6 = read v4.__fn
+      let env7 = read v4.__env
+      let v8 = call *fnref6(env7, v5)
+      return v8",
     "name": "forcedStr",
     "normalized": ""hello"",
     "solverTrace": "=== Formula ===
@@ -182,17 +204,27 @@ exports[`Language Tour — Polymorphism > implicit parameters 1`] = `
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_10;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_10;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_11(x) {
-  return x;
+function closure_11(env0, x1) {
+  return x1;
 }
 
-function closure_10(a) {
-  const v0 = closure_11;
-  return v0;
+function closure_10(env0, a1) {
+  const env_cls2 = {};
+  const fnref_cls2 = closure_11;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 return main();
 ",
@@ -231,15 +263,19 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_10
-      return v0
-  fn closure_11(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_10
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_11(env0, x1) entry=entry
     entry:
-      return x
-  fn closure_10(a) entry=entry
+      return x1
+  fn closure_10(env0, a1) entry=entry
     entry:
-      let v0 = &closure_11
-      return v0",
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_11
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "id",
     "normalized": "λ(a: Type) => (closure: λ(x: a) -> x -| Γ: a)",
     "solverTrace": "=== Formula ===
@@ -286,10 +322,14 @@ return main();
     "codegenJS": "function main() {
   const v0 = id;
   const v1 = "Num";
-  const v2 = v0(v1);
-  const v3 = 42;
-  const v4 = v2(v3);
-  return v4;
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  const v5 = 42;
+  const fnref6 = v4.__fn;
+  const env7 = v4.__env;
+  const v8 = fnref6(env7, v5);
+  return v8;
 }
 return main();
 ",
@@ -316,10 +356,14 @@ return main();
     entry:
       let v0 = id
       let v1 = Num
-      let v2 = call *v0(v1)
-      let v3 = 42
-      let v4 = call *v2(v3)
-      return v4",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      let v5 = 42
+      let fnref6 = read v4.__fn
+      let env7 = read v4.__env
+      let v8 = call *fnref6(env7, v5)
+      return v8",
     "name": "n2",
     "normalized": "42",
     "solverTrace": "=== Formula ===
@@ -354,10 +398,14 @@ return main();
     "codegenJS": "function main() {
   const v0 = id;
   const v1 = "String";
-  const v2 = v0(v1);
-  const v3 = "hello";
-  const v4 = v2(v3);
-  return v4;
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  const v5 = "hello";
+  const fnref6 = v4.__fn;
+  const env7 = v4.__env;
+  const v8 = fnref6(env7, v5);
+  return v8;
 }
 return main();
 ",
@@ -384,10 +432,14 @@ return main();
     entry:
       let v0 = id
       let v1 = String
-      let v2 = call *v0(v1)
-      let v3 = "hello"
-      let v4 = call *v2(v3)
-      return v4",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      let v5 = "hello"
+      let fnref6 = read v4.__fn
+      let env7 = read v4.__env
+      let v8 = call *fnref6(env7, v5)
+      return v8",
     "name": "s2",
     "normalized": ""hello"",
     "solverTrace": "=== Formula ===
@@ -424,9 +476,36 @@ return main();
 exports[`Language Tour — Polymorphism > implicit resolution with using 1`] = `
 [
   {
-    "codegenJS": "",
+    "codegenJS": "function main() {
+  const env_cls2 = {};
+  const fnref_cls2 = closure_16;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_17(env0, x1) {
+  const cap_0 = env0.v0;
+  const v0 = (x1 + cap_0);
+  return v0;
+}
+
+function closure_16(env0, n1) {
+  const env_cls2 = {
+    v0: n1
+  };
+  const fnref_cls2 = closure_17;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+return main();
+",
     "elaborated": "λ(n: Num) => λ(x: Num) -> FFI.$add x n",
-    "error": "Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures",
     "gram": "[1] root
   :entry -> [3]
 [2] stmt:let {"variable":"addImplicit"}
@@ -467,7 +546,24 @@ exports[`Language Tour — Polymorphism > implicit resolution with using 1`] = `
   :env -> [15]",
     "ivl": "(forall ((n Real)) (forall ((x Real)) (and (= x x) (= n n))))",
     "kind": "let",
-    "mir": "",
+    "mir": "module
+  fn main entry=entry
+    entry:
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_16
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_17(env0, x1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let v0 = +(x1, cap_0)
+      return v0
+  fn closure_16(env0, n1) entry=entry
+    entry:
+      let env_cls2 = alloc { v0: n1 }
+      let fnref_cls2 = &closure_17
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "addImplicit",
     "normalized": "λ(n: Num) => (closure: λ(x: Num) -> FFI.$add x n -| Γ: n)",
     "solverTrace": "=== Formula ===
@@ -520,10 +616,14 @@ exports[`Language Tour — Polymorphism > implicit resolution with using 1`] = `
     "codegenJS": "function main() {
   const v0 = addImplicit;
   const v1 = 10;
-  const v2 = v0(v1);
-  const v3 = 1;
-  const v4 = v2(v3);
-  return v4;
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  const v5 = 1;
+  const fnref6 = v4.__fn;
+  const env7 = v4.__env;
+  const v8 = fnref6(env7, v5);
+  return v8;
 }
 return main();
 ",
@@ -550,10 +650,14 @@ return main();
     entry:
       let v0 = addImplicit
       let v1 = 10
-      let v2 = call *v0(v1)
-      let v3 = 1
-      let v4 = call *v2(v3)
-      return v4",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      let v5 = 1
+      let fnref6 = read v4.__fn
+      let env7 = read v4.__env
+      let v8 = call *fnref6(env7, v5)
+      return v8",
     "name": "eleven",
     "normalized": "11",
     "solverTrace": "=== Formula ===
@@ -588,10 +692,14 @@ return main();
     "codegenJS": "function main() {
   const v0 = addImplicit;
   const v1 = 10;
-  const v2 = v0(v1);
-  const v3 = 5;
-  const v4 = v2(v3);
-  return v4;
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  const v5 = 5;
+  const fnref6 = v4.__fn;
+  const env7 = v4.__env;
+  const v8 = fnref6(env7, v5);
+  return v8;
 }
 return main();
 ",
@@ -618,10 +726,14 @@ return main();
     entry:
       let v0 = addImplicit
       let v1 = 10
-      let v2 = call *v0(v1)
-      let v3 = 5
-      let v4 = call *v2(v3)
-      return v4",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      let v5 = 5
+      let fnref6 = read v4.__fn
+      let env7 = read v4.__env
+      let v8 = call *fnref6(env7, v5)
+      return v8",
     "name": "fifteen",
     "normalized": "15",
     "solverTrace": "=== Formula ===
@@ -659,13 +771,18 @@ exports[`Language Tour — Polymorphism > inference and generalization 1`] = `
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_13;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_13;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_13(x) {
+function closure_13(env0, x1) {
   const v0 = 1;
-  const v1 = (x + v0);
+  const v1 = (x1 + v0);
   return v1;
 }
 return main();
@@ -711,12 +828,14 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_13
-      return v0
-  fn closure_13(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_13
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_13(env0, x1) entry=entry
     entry:
       let v0 = 1
-      let v1 = +(x, v0)
+      let v1 = +(x1, v0)
       return v1",
     "name": "inc",
     "normalized": "λ(x: Num) -> (closure: FFI.$add x 1 -| Γ: x)",
@@ -776,11 +895,63 @@ return main();
     "validity": "valid",
   },
   {
-    "codegenJS": "",
+    "codegenJS": "function main() {
+  const env_cls2 = {};
+  const fnref_cls2 = closure_16;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_19(env0, y1) {
+  const cap_0 = env0.v0;
+  return cap_0;
+}
+
+function closure_18(env0, x1) {
+  const cap_0 = env0.v0;
+  const env_cls2 = {
+    v0: x1
+  };
+  const fnref_cls2 = closure_19;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_17(env0, b1) {
+  const cap_0 = env0.v0;
+  const env_cls2 = {
+    v0: b1
+  };
+  const fnref_cls2 = closure_18;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_16(env0, a1) {
+  const env_cls2 = {
+    v0: a1
+  };
+  const fnref_cls2 = closure_17;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+return main();
+",
     "elaborated": "λ(a: Type) =>
   λ(b: Type) =>
     (λ(x: a) -> (λ(y: b) -> x : Π(y: b) -> a) : Π(x: a) -> Π(y: b) -> a)",
-    "error": "Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures",
     "gram": "[1] root
   :entry -> [3]
 [2] stmt:let {"variable":"fst"}
@@ -842,7 +1013,37 @@ return main();
     "ivl": "(forall ((a Type))
   (forall ((b Type)) (forall ((x Type)) (forall ((y Type)) (= x x)))))",
     "kind": "let",
-    "mir": "",
+    "mir": "module
+  fn main entry=entry
+    entry:
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_16
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_19(env0, y1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      return cap_0
+  fn closure_18(env0, x1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let env_cls2 = alloc { v0: x1 }
+      let fnref_cls2 = &closure_19
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_17(env0, b1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let env_cls2 = alloc { v0: b1 }
+      let fnref_cls2 = &closure_18
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_16(env0, a1) entry=entry
+    entry:
+      let env_cls2 = alloc { v0: a1 }
+      let fnref_cls2 = &closure_17
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "fst",
     "normalized": "λ(a: Type) =>
   (closure: λ(b: Type) =>
@@ -898,28 +1099,46 @@ exports[`Language Tour — Polymorphism > let-polymorphism in blocks 1`] = `
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_25;
-  const innerID1 = v0;
-  const v2 = "Num";
-  const v3 = innerID1(v2);
-  const v4 = 42;
-  const v5 = v3(v4);
-  const n6 = v5;
-  const v7 = "String";
-  const v8 = innerID1(v7);
-  const v9 = "hi";
-  const v10 = v8(v9);
-  const s11 = v10;
-  return n6;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_25;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  const innerID3 = closure_cls2;
+  const v4 = "Num";
+  const fnref5 = innerID3.__fn;
+  const env6 = innerID3.__env;
+  const v7 = fnref5(env6, v4);
+  const v8 = 42;
+  const fnref9 = v7.__fn;
+  const env10 = v7.__env;
+  const v11 = fnref9(env10, v8);
+  const n12 = v11;
+  const v13 = "String";
+  const fnref14 = innerID3.__fn;
+  const env15 = innerID3.__env;
+  const v16 = fnref14(env15, v13);
+  const v17 = "hi";
+  const fnref18 = v16.__fn;
+  const env19 = v16.__env;
+  const v20 = fnref18(env19, v17);
+  const s21 = v20;
+  return n12;
 }
 
-function closure_26(x) {
-  return x;
+function closure_26(env0, x1) {
+  return x1;
 }
 
-function closure_25(a) {
-  const v0 = closure_26;
-  return v0;
+function closure_25(env0, a1) {
+  const env_cls2 = {};
+  const fnref_cls2 = closure_26;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 return main();
 ",
@@ -1015,26 +1234,38 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_25
-      let innerID1 = v0
-      let v2 = Num
-      let v3 = call *innerID1(v2)
-      let v4 = 42
-      let v5 = call *v3(v4)
-      let n6 = v5
-      let v7 = String
-      let v8 = call *innerID1(v7)
-      let v9 = "hi"
-      let v10 = call *v8(v9)
-      let s11 = v10
-      return n6
-  fn closure_26(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_25
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      let innerID3 = closure_cls2
+      let v4 = Num
+      let fnref5 = read innerID3.__fn
+      let env6 = read innerID3.__env
+      let v7 = call *fnref5(env6, v4)
+      let v8 = 42
+      let fnref9 = read v7.__fn
+      let env10 = read v7.__env
+      let v11 = call *fnref9(env10, v8)
+      let n12 = v11
+      let v13 = String
+      let fnref14 = read innerID3.__fn
+      let env15 = read innerID3.__env
+      let v16 = call *fnref14(env15, v13)
+      let v17 = "hi"
+      let fnref18 = read v16.__fn
+      let env19 = read v16.__env
+      let v20 = call *fnref18(env19, v17)
+      let s21 = v20
+      return n12
+  fn closure_26(env0, x1) entry=entry
     entry:
-      return x
-  fn closure_25(a) entry=entry
+      return x1
+  fn closure_25(env0, a1) entry=entry
     entry:
-      let v0 = &closure_26
-      return v0",
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_26
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "letpoly",
     "normalized": "42",
     "solverTrace": "=== Formula ===
@@ -1087,17 +1318,27 @@ exports[`Language Tour — Polymorphism > parametric polymorphism 1`] = `
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_10;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_10;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_11(x) {
-  return x;
+function closure_11(env0, x1) {
+  return x1;
 }
 
-function closure_10(a) {
-  const v0 = closure_11;
-  return v0;
+function closure_10(env0, a1) {
+  const env_cls2 = {};
+  const fnref_cls2 = closure_11;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 return main();
 ",
@@ -1136,15 +1377,19 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_10
-      return v0
-  fn closure_11(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_10
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_11(env0, x1) entry=entry
     entry:
-      return x
-  fn closure_10(a) entry=entry
+      return x1
+  fn closure_10(env0, a1) entry=entry
     entry:
-      let v0 = &closure_11
-      return v0",
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_11
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "id",
     "normalized": "λ(a: Type) -> (closure: λ(x: a) -> x -| Γ: a)",
     "solverTrace": "=== Formula ===
@@ -1188,9 +1433,61 @@ return main();
     "validity": "valid",
   },
   {
-    "codegenJS": "",
+    "codegenJS": "function main() {
+  const env_cls2 = {};
+  const fnref_cls2 = closure_16;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_19(env0, y1) {
+  const cap_0 = env0.v0;
+  return cap_0;
+}
+
+function closure_18(env0, x1) {
+  const cap_0 = env0.v0;
+  const env_cls2 = {
+    v0: x1
+  };
+  const fnref_cls2 = closure_19;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_17(env0, b1) {
+  const cap_0 = env0.v0;
+  const env_cls2 = {
+    v0: b1
+  };
+  const fnref_cls2 = closure_18;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_16(env0, a1) {
+  const env_cls2 = {
+    v0: a1
+  };
+  const fnref_cls2 = closure_17;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+return main();
+",
     "elaborated": "λ(a: Type) -> λ(b: Type) -> λ(x: a) -> λ(y: b) -> x",
-    "error": "Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures",
     "gram": "[1] root
   :entry -> [3]
 [2] stmt:let {"variable":"const"}
@@ -1252,7 +1549,37 @@ return main();
     "ivl": "(forall ((a Type))
   (forall ((b Type)) (forall ((x Type)) (forall ((y Type)) (= x x)))))",
     "kind": "let",
-    "mir": "",
+    "mir": "module
+  fn main entry=entry
+    entry:
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_16
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_19(env0, y1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      return cap_0
+  fn closure_18(env0, x1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let env_cls2 = alloc { v0: x1 }
+      let fnref_cls2 = &closure_19
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_17(env0, b1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let env_cls2 = alloc { v0: b1 }
+      let fnref_cls2 = &closure_18
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_16(env0, a1) entry=entry
+    entry:
+      let env_cls2 = alloc { v0: a1 }
+      let fnref_cls2 = &closure_17
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "const",
     "normalized": "λ(a: Type) -> (closure: λ(b: Type) -> λ(x: a) -> λ(y: b) -> x -| Γ: a)",
     "solverTrace": "=== Formula ===

--- a/src/__tests__/integration/__snapshots__/records.test.ts.snap
+++ b/src/__tests__/integration/__snapshots__/records.test.ts.snap
@@ -283,12 +283,17 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_20;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_20;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_20(p) {
-  const v0 = p.x;
+function closure_20(env0, p1) {
+  const v0 = p1.x;
   return v0;
 }
 return main();
@@ -341,11 +346,13 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_20
-      return v0
-  fn closure_20(p) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_20
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_20(env0, p1) entry=entry
     entry:
-      let v0 = read p.x
+      let v0 = read p1.x
       return v0",
     "name": "getX",
     "normalized": "λ(p: Σ($sig: [ y: Num, x: Num ]) . (closure: Schema [ y: Num, x: Num ] -| ·)) ->

--- a/src/__tests__/integration/__snapshots__/refinement-types.test.ts.snap
+++ b/src/__tests__/integration/__snapshots__/refinement-types.test.ts.snap
@@ -442,16 +442,23 @@ exports[`Language Tour — Refinement Types > block refinement obligations 1`] =
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_19;
-  const f1 = v0;
-  const v2 = 1;
-  const v3 = f1(v2);
-  return v3;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_19;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  const f3 = closure_cls2;
+  const v4 = 1;
+  const fnref5 = f3.__fn;
+  const env6 = f3.__env;
+  const v7 = fnref5(env6, v4);
+  return v7;
 }
 
-function closure_19(o) {
+function closure_19(env0, o1) {
   const v0 = 1;
-  const v1 = (o + v0);
+  const v1 = (o1 + v0);
   return v1;
 }
 return main();
@@ -520,15 +527,19 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_19
-      let f1 = v0
-      let v2 = 1
-      let v3 = call *f1(v2)
-      return v3
-  fn closure_19(o) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_19
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      let f3 = closure_cls2
+      let v4 = 1
+      let fnref5 = read f3.__fn
+      let env6 = read f3.__env
+      let v7 = call *fnref5(env6, v4)
+      return v7
+  fn closure_19(env0, o1) entry=entry
     entry:
       let v0 = 1
-      let v1 = +(o, v0)
+      let v1 = +(o1, v0)
       return v1",
     "name": "block",
     "normalized": "2",
@@ -611,13 +622,23 @@ exports[`Language Tour — Refinement Types > block-local let obligations verify
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_24;
-  return v0;
+  const env_cls2 = {
+    v0: doubled,
+    v1: added
+  };
+  const fnref_cls2 = closure_24;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_24(doubled, added, x) {
+function closure_24(env0, x1) {
+  const cap_0 = env0.v0;
+  const cap_1 = env0.v1;
   const v0 = 2;
-  const v1 = (x * v0);
+  const v1 = (x1 * v0);
   const doubled2 = v1;
   const v3 = 10;
   const v4 = (doubled2 + v3);
@@ -727,12 +748,16 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_24
-      return v0
-  fn closure_24(doubled, added, x) entry=entry
+      let env_cls2 = alloc { v0: doubled, v1: added }
+      let fnref_cls2 = &closure_24
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_24(env0, x1) entry=entry
     entry:
+      let cap_0 = read env0.v0
+      let cap_1 = read env0.v1
       let v0 = 2
-      let v1 = *(x, v0)
+      let v1 = *(x1, v0)
       let doubled2 = v1
       let v3 = 10
       let v4 = +(doubled2, v3)
@@ -955,14 +980,21 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_12;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_12;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_12(f) {
+function closure_12(env0, f1) {
   const v0 = 10;
-  const v1 = f(v0);
-  return v1;
+  const fnref1 = f1.__fn;
+  const env2 = f1.__env;
+  const v3 = fnref1(env2, v0);
+  return v3;
 }
 return main();
 ",
@@ -998,13 +1030,17 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_12
-      return v0
-  fn closure_12(f) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_12
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_12(env0, f1) entry=entry
     entry:
       let v0 = 10
-      let v1 = call *f(v0)
-      return v1",
+      let fnref1 = read f1.__fn
+      let env2 = read f1.__env
+      let v3 = call *fnref1(env2, v0)
+      return v3",
     "name": "takePosFunction",
     "normalized": "λ(f: Π(t2: <ω> Num [| λ(p: Num) -> (closure: FFI.$gt p 0 -| Γ: p) |]) ->
   (closure: Num -| Γ: t2)) ->
@@ -1051,12 +1087,17 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_8;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_8;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_8(x) {
-  return x;
+function closure_8(env0, x1) {
+  return x1;
 }
 return main();
 ",
@@ -1084,11 +1125,13 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_8
-      return v0
-  fn closure_8(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_8
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_8(env0, x1) entry=entry
     entry:
-      return x",
+      return x1",
     "name": "natToNum",
     "normalized": "λ(x: <ω> Num [| λ(n: Num) -> (closure: FFI.$gte n 0 -| Γ: n) |]) ->
   (closure: x -| Γ: x)",
@@ -1134,12 +1177,17 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_8;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_8;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_8(x) {
-  return x;
+function closure_8(env0, x1) {
+  return x1;
 }
 return main();
 ",
@@ -1167,11 +1215,13 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_8
-      return v0
-  fn closure_8(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_8
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_8(env0, x1) entry=entry
     entry:
-      return x",
+      return x1",
     "name": "posToNum",
     "normalized": "λ(x: <ω> Num [| λ(p: Num) -> (closure: FFI.$gt p 0 -| Γ: p) |]) ->
   (closure: x -| Γ: x)",
@@ -1219,8 +1269,10 @@ return main();
     "codegenJS": "function main() {
   const v0 = takePosFunction;
   const v1 = natToNum;
-  const v2 = v0(v1);
-  return v2;
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  return v4;
 }
 return main();
 ",
@@ -1246,8 +1298,10 @@ return main();
     entry:
       let v0 = takePosFunction
       let v1 = natToNum
-      let v2 = call *v0(v1)
-      return v2",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      return v4",
     "name": "result1",
     "normalized": "10",
     "solverTrace": "=== Formula ===
@@ -1293,8 +1347,10 @@ return main();
     "codegenJS": "function main() {
   const v0 = takePosFunction;
   const v1 = posToNum;
-  const v2 = v0(v1);
-  return v2;
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  return v4;
 }
 return main();
 ",
@@ -1320,8 +1376,10 @@ return main();
     entry:
       let v0 = takePosFunction
       let v1 = posToNum
-      let v2 = call *v0(v1)
-      return v2",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      return v4",
     "name": "result2",
     "normalized": "10",
     "solverTrace": "=== Formula ===
@@ -1369,7 +1427,59 @@ return main();
 exports[`Language Tour — Refinement Types > dependent record construction 1`] = `
 [
   {
-    "codegenJS": "",
+    "codegenJS": "function main() {
+  const env_cls2 = {};
+  const fnref_cls2 = closure_42;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  const Pair3 = closure_cls2;
+  const v4 = 2;
+  const v5 = 1;
+  const v6 = {
+    snd: v4,
+    fst: v5
+  };
+  const p7 = v6;
+  const v8 = null;
+  return v8;
+}
+
+function closure_44(env0, p1) {
+  const cap_0 = env0.v0;
+  const cap_1 = env0.v1;
+  const v0 = {};
+  return v0;
+}
+
+function closure_43(env0, b1) {
+  const cap_0 = env0.v0;
+  const env_cls2 = {
+    v0: b1,
+    v1: cap_0
+  };
+  const fnref_cls2 = closure_44;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_42(env0, a1) {
+  const env_cls2 = {
+    v0: a1
+  };
+  const fnref_cls2 = closure_43;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+return main();
+",
     "elaborated": "{
   let Pair
     : Π(a: Type) ->
@@ -1390,7 +1500,6 @@ exports[`Language Tour — Refinement Types > dependent record construction 1`] 
     = Struct [ snd: 2, fst: 1 ];
   return unit;
 }",
-    "error": "Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures",
     "gram": "[1] root
   :entry -> [3]
 [2] stmt:let {"variable":"test"}
@@ -1523,7 +1632,38 @@ exports[`Language Tour — Refinement Types > dependent record construction 1`] 
   :env -> [41]",
     "ivl": "(forall ((p Schema)) (forall (($a Real)) (=> (= $a 2) (< 1 $a))))",
     "kind": "let",
-    "mir": "",
+    "mir": "module
+  fn main entry=entry
+    entry:
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_42
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      let Pair3 = closure_cls2
+      let v4 = 2
+      let v5 = 1
+      let v6 = alloc { snd: v4, fst: v5 }
+      let p7 = v6
+      let v8 = unit
+      return v8
+  fn closure_44(env0, p1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let cap_1 = read env0.v1
+      let v0 = alloc {  }
+      return v0
+  fn closure_43(env0, b1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let env_cls2 = alloc { v0: b1, v1: cap_0 }
+      let fnref_cls2 = &closure_44
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_42(env0, a1) entry=entry
+    entry:
+      let env_cls2 = alloc { v0: a1 }
+      let fnref_cls2 = &closure_43
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "test",
     "normalized": "unit",
     "solverTrace": "=== Formula ===
@@ -1572,7 +1712,59 @@ exports[`Language Tour — Refinement Types > dependent record construction 1`] 
 exports[`Language Tour — Refinement Types > dependent record construction rejects invalid field 1`] = `
 [
   {
-    "codegenJS": "",
+    "codegenJS": "function main() {
+  const env_cls2 = {};
+  const fnref_cls2 = closure_42;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  const Pair3 = closure_cls2;
+  const v4 = 1;
+  const v5 = 2;
+  const v6 = {
+    snd: v4,
+    fst: v5
+  };
+  const p7 = v6;
+  const v8 = 1;
+  return v8;
+}
+
+function closure_44(env0, p1) {
+  const cap_0 = env0.v0;
+  const cap_1 = env0.v1;
+  const v0 = {};
+  return v0;
+}
+
+function closure_43(env0, b1) {
+  const cap_0 = env0.v0;
+  const env_cls2 = {
+    v0: b1,
+    v1: cap_0
+  };
+  const fnref_cls2 = closure_44;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_42(env0, a1) {
+  const env_cls2 = {
+    v0: a1
+  };
+  const fnref_cls2 = closure_43;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+return main();
+",
     "elaborated": "{
   let Pair
     : Π(a: Type) ->
@@ -1593,7 +1785,6 @@ exports[`Language Tour — Refinement Types > dependent record construction reje
     = Struct [ snd: 1, fst: 2 ];
   return 1;
 }",
-    "error": "Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures",
     "gram": "[1] root
   :entry -> [3]
 [2] stmt:let {"variable":"testFail"}
@@ -1726,7 +1917,38 @@ exports[`Language Tour — Refinement Types > dependent record construction reje
   :env -> [41]",
     "ivl": "(forall ((p Schema)) (forall (($a Real)) (=> (= $a 1) (< 2 $a))))",
     "kind": "let",
-    "mir": "",
+    "mir": "module
+  fn main entry=entry
+    entry:
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_42
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      let Pair3 = closure_cls2
+      let v4 = 1
+      let v5 = 2
+      let v6 = alloc { snd: v4, fst: v5 }
+      let p7 = v6
+      let v8 = 1
+      return v8
+  fn closure_44(env0, p1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let cap_1 = read env0.v1
+      let v0 = alloc {  }
+      return v0
+  fn closure_43(env0, b1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let env_cls2 = alloc { v0: b1, v1: cap_0 }
+      let fnref_cls2 = &closure_44
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_42(env0, a1) entry=entry
+    entry:
+      let env_cls2 = alloc { v0: a1 }
+      let fnref_cls2 = &closure_43
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "testFail",
     "normalized": "1",
     "solverTrace": "=== Formula ===
@@ -2105,11 +2327,16 @@ exports[`Language Tour — Refinement Types > function refinement obligations 1`
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_7;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_7;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_7(x) {
+function closure_7(env0, x1) {
   const v0 = 2;
   return v0;
 }
@@ -2134,9 +2361,11 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_7
-      return v0
-  fn closure_7(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_7
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_7(env0, x1) entry=entry
     entry:
       let v0 = 2
       return v0",
@@ -2172,11 +2401,16 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_7;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_7;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_7(x) {
+function closure_7(env0, x1) {
   const v0 = 1;
   return v0;
 }
@@ -2201,9 +2435,11 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_7
-      return v0
-  fn closure_7(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_7
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_7(env0, x1) entry=entry
     entry:
       let v0 = 1
       return v0",
@@ -2251,12 +2487,17 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_8;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_8;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_8(x) {
-  return x;
+function closure_8(env0, x1) {
+  return x1;
 }
 return main();
 ",
@@ -2284,11 +2525,13 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_8
-      return v0
-  fn closure_8(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_8
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_8(env0, x1) entry=entry
     entry:
-      return x",
+      return x1",
     "name": "posTestCheckLambdaPreCondition",
     "normalized": "λ(x: <ω> Num [| λ(n: Num) -> (closure: FFI.$gt n 0 -| Γ: n) |]) ->
   (closure: x -| Γ: x)",
@@ -2334,12 +2577,17 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_8;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_8;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_8(x) {
-  return x;
+function closure_8(env0, x1) {
+  return x1;
 }
 return main();
 ",
@@ -2373,11 +2621,13 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_8
-      return v0
-  fn closure_8(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_8
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_8(env0, x1) entry=entry
     entry:
-      return x",
+      return x1",
     "name": "posTestCheckLambdaPreAndPostCondition",
     "normalized": "λ(x: <ω> Num [| λ(n: Num) -> (closure: FFI.$gt n 0 -| Γ: n) |]) ->
   (closure: x -| Γ: x)",
@@ -2432,13 +2682,18 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_13;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_13;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_13(x) {
+function closure_13(env0, x1) {
   const v0 = 1;
-  const v1 = (x + v0);
+  const v1 = (x1 + v0);
   return v1;
 }
 return main();
@@ -2479,12 +2734,14 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_13
-      return v0
-  fn closure_13(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_13
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_13(env0, x1) entry=entry
     entry:
       let v0 = 1
-      let v1 = +(x, v0)
+      let v1 = +(x1, v0)
       return v1",
     "name": "posTestCheckRefinedResultLambda",
     "normalized": "λ(x: Num) -> (closure: FFI.$add x 1 -| Γ: x)",
@@ -2541,13 +2798,18 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_13;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_13;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_13(x) {
+function closure_13(env0, x1) {
   const v0 = 1;
-  const v1 = (x + v0);
+  const v1 = (x1 + v0);
   return v1;
 }
 return main();
@@ -2588,12 +2850,14 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_13
-      return v0
-  fn closure_13(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_13
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_13(env0, x1) entry=entry
     entry:
       let v0 = 1
-      let v1 = +(x, v0)
+      let v1 = +(x1, v0)
       return v1",
     "name": "inc",
     "normalized": "λ(x: Num) -> (closure: FFI.$add x 1 -| Γ: x)",
@@ -2759,14 +3023,21 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_13;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_13;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_13(f) {
+function closure_13(env0, f1) {
   const v0 = 1;
-  const v1 = f(v0);
-  return v1;
+  const fnref1 = f1.__fn;
+  const env2 = f1.__env;
+  const v3 = fnref1(env2, v0);
+  return v3;
 }
 return main();
 ",
@@ -2808,13 +3079,17 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_13
-      return v0
-  fn closure_13(f) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_13
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_13(env0, f1) entry=entry
     entry:
       let v0 = 1
-      let v1 = call *f(v0)
-      return v1",
+      let fnref1 = read f1.__fn
+      let env2 = read f1.__env
+      let v3 = call *fnref1(env2, v0)
+      return v3",
     "name": "hof",
     "normalized": "λ(f: Π(t1: <ω> Num [| λ(n: Num) -> (closure: FFI.$gte n 0 -| Γ: n) |]) ->
   (closure: <ω> Num [| λ(n: Num) -> FFI.$gte n 0 |] -| Γ: t1)) ->
@@ -2869,16 +3144,23 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_18;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_18;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_18(f) {
+function closure_18(env0, f1) {
   const v0 = 1;
-  const v1 = f(v0);
-  const v2 = 1;
-  const v3 = (v1 + v2);
-  return v3;
+  const fnref1 = f1.__fn;
+  const env2 = f1.__env;
+  const v3 = fnref1(env2, v0);
+  const v4 = 1;
+  const v5 = (v3 + v4);
+  return v5;
 }
 return main();
 ",
@@ -2928,15 +3210,19 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_18
-      return v0
-  fn closure_18(f) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_18
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_18(env0, f1) entry=entry
     entry:
       let v0 = 1
-      let v1 = call *f(v0)
-      let v2 = 1
-      let v3 = +(v1, v2)
-      return v3",
+      let fnref1 = read f1.__fn
+      let env2 = read f1.__env
+      let v3 = call *fnref1(env2, v0)
+      let v4 = 1
+      let v5 = +(v3, v4)
+      return v5",
     "name": "hof2",
     "normalized": "λ(f: Π(t3: Num) ->
   (closure: <ω> Num [| λ(n: Num) -> FFI.$gte n 0 |] -| Γ: t3)) ->
@@ -3006,13 +3292,18 @@ exports[`Language Tour — Refinement Types > input-output relationship 1`] = `
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_13;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_13;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_13(x) {
+function closure_13(env0, x1) {
   const v0 = 1;
-  const v1 = (x + v0);
+  const v1 = (x1 + v0);
   return v1;
 }
 return main();
@@ -3053,12 +3344,14 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_13
-      return v0
-  fn closure_13(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_13
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_13(env0, x1) entry=entry
     entry:
       let v0 = 1
-      let v1 = +(x, v0)
+      let v1 = +(x1, v0)
       return v1",
     "name": "inc",
     "normalized": "λ(x: Num) -> (closure: FFI.$add x 1 -| Γ: x)",
@@ -3299,11 +3592,16 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_8;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_8;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_8(x) {
+function closure_8(env0, x1) {
   const v0 = 0;
   return v0;
 }
@@ -3330,9 +3628,11 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_8
-      return v0
-  fn closure_8(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_8
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_8(env0, x1) entry=entry
     entry:
       let v0 = 0
       return v0",
@@ -4609,12 +4909,17 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_8;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_8;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_8(x) {
-  return x;
+function closure_8(env0, x1) {
+  return x1;
 }
 return main();
 ",
@@ -4648,11 +4953,13 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_8
-      return v0
-  fn closure_8(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_8
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_8(env0, x1) entry=entry
     entry:
-      return x",
+      return x1",
     "name": "safe",
     "normalized": "λ(x: <ω> Num [| λ(n: Num) -> (closure: FFI.$gte n 0 -| Γ: n) |]) ->
   (closure: x -| Γ: x)",
@@ -4712,17 +5019,27 @@ exports[`Language Tour — Refinement Types > refinement polymorphism 1`] = `
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_13;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_13;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_14(x) {
-  return x;
+function closure_14(env0, x1) {
+  return x1;
 }
 
-function closure_13(p) {
-  const v0 = closure_14;
-  return v0;
+function closure_13(env0, p1) {
+  const env_cls2 = {};
+  const fnref_cls2 = closure_14;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 return main();
 ",
@@ -4765,15 +5082,19 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_13
-      return v0
-  fn closure_14(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_13
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_14(env0, x1) entry=entry
     entry:
-      return x
-  fn closure_13(p) entry=entry
+      return x1
+  fn closure_13(env0, p1) entry=entry
     entry:
-      let v0 = &closure_14
-      return v0",
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_14
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "checkNum",
     "normalized": "λ(p: Π(t1: Num) -> (closure: Bool -| Γ: t1)) ->
   (closure: λ(x: <ω> Num [| λ(v: Num) -> p v |]) -> x -| Γ: p)",
@@ -4820,17 +5141,26 @@ return main();
   {
     "codegenJS": "function main() {
   const v0 = checkNum;
-  const v1 = closure_18;
-  const v2 = v0(v1);
-  const v3 = 5;
-  const v4 = v2(v3);
-  return v4;
+  const env_cls3 = {};
+  const fnref_cls3 = closure_18;
+  const closure_cls3 = {
+    __fn: fnref_cls3,
+    __env: env_cls3
+  };
+  const fnref4 = v0.__fn;
+  const env5 = v0.__env;
+  const v6 = fnref4(env5, closure_cls3);
+  const v7 = 5;
+  const fnref8 = v6.__fn;
+  const env9 = v6.__env;
+  const v10 = fnref8(env9, v7);
+  return v10;
 }
 
-function closure_18(n) {
-  const v0 = 0;
-  const v1 = (n >= v0);
-  return v1;
+function closure_18(env1, n2) {
+  const v1 = 0;
+  const v2 = (n2 >= v1);
+  return v2;
 }
 return main();
 ",
@@ -4875,16 +5205,22 @@ return main();
   fn main entry=entry
     entry:
       let v0 = checkNum
-      let v1 = &closure_18
-      let v2 = call *v0(v1)
-      let v3 = 5
-      let v4 = call *v2(v3)
-      return v4
-  fn closure_18(n) entry=entry
+      let env_cls3 = alloc {  }
+      let fnref_cls3 = &closure_18
+      let closure_cls3 = alloc { __fn: fnref_cls3, __env: env_cls3 }
+      let fnref4 = read v0.__fn
+      let env5 = read v0.__env
+      let v6 = call *fnref4(env5, closure_cls3)
+      let v7 = 5
+      let fnref8 = read v6.__fn
+      let env9 = read v6.__env
+      let v10 = call *fnref8(env9, v7)
+      return v10
+  fn closure_18(env1, n2) entry=entry
     entry:
-      let v0 = 0
-      let v1 = >=(n, v0)
-      return v1",
+      let v1 = 0
+      let v2 = >=(n2, v1)
+      return v2",
     "name": "nat5",
     "normalized": "5",
     "solverTrace": "=== Formula ===
@@ -5042,12 +5378,17 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_8;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_8;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_8(n) {
-  return n;
+function closure_8(env0, n1) {
+  return n1;
 }
 return main();
 ",
@@ -5075,11 +5416,13 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_8
-      return v0
-  fn closure_8(n) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_8
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_8(env0, n1) entry=entry
     entry:
-      return n",
+      return n1",
     "name": "useNat",
     "normalized": "λ(n: <ω> Num [| λ(n: Num) -> (closure: FFI.$gte n 0 -| Γ: n) |]) ->
   (closure: n -| Γ: n)",
@@ -5188,8 +5531,10 @@ return main();
     "codegenJS": "function main() {
   const v0 = useNat;
   const v1 = p;
-  const v2 = v0(v1);
-  return v2;
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  return v4;
 }
 return main();
 ",
@@ -5215,8 +5560,10 @@ return main();
     entry:
       let v0 = useNat
       let v1 = p
-      let v2 = call *v0(v1)
-      return v2",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      return v4",
     "name": "result",
     "normalized": "42",
     "solverTrace": "=== Formula ===
@@ -5265,12 +5612,17 @@ exports[`Language Tour — Refinement Types > unconstrained identity fails posit
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_7;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_7;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_7(x) {
-  return x;
+function closure_7(env0, x1) {
+  return x1;
 }
 return main();
 ",
@@ -5296,11 +5648,13 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_7
-      return v0
-  fn closure_7(x) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_7
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_7(env0, x1) entry=entry
     entry:
-      return x",
+      return x1",
     "name": "negTestCheckLambdaPostCondition",
     "normalized": "λ(x: Num) -> (closure: x -| Γ: x)",
     "solverTrace": "=== Formula ===

--- a/src/__tests__/integration/__snapshots__/row-polymorphism.test.ts.snap
+++ b/src/__tests__/integration/__snapshots__/row-polymorphism.test.ts.snap
@@ -4,18 +4,28 @@ exports[`Language Tour — Row Polymorphism > open records 1`] = `
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_19;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_19;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_20(env0, record1) {
+  const v0 = record1.x;
   return v0;
 }
 
-function closure_20(record) {
-  const v0 = record.x;
-  return v0;
-}
-
-function closure_19(r) {
-  const v0 = closure_20;
-  return v0;
+function closure_19(env0, r1) {
+  const env_cls2 = {};
+  const fnref_cls2 = closure_20;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 return main();
 ",
@@ -77,16 +87,20 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_19
-      return v0
-  fn closure_20(record) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_19
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_20(env0, record1) entry=entry
     entry:
-      let v0 = read record.x
+      let v0 = read record1.x
       return v0
-  fn closure_19(r) entry=entry
+  fn closure_19(env0, r1) entry=entry
     entry:
-      let v0 = &closure_20
-      return v0",
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_20
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "getX",
     "normalized": "λ(r: Row) =>
   (closure: λ(record: Σ($sig: [ x: Num | r ]) . Schema [ x: Num | r ]) ->
@@ -126,15 +140,19 @@ return main();
   const v2 = {
     y: v1
   };
-  const v3 = v0(v2);
-  const v4 = 10;
-  const v5 = 20;
-  const v6 = {
-    x: v4,
-    y: v5
+  const fnref3 = v0.__fn;
+  const env4 = v0.__env;
+  const v5 = fnref3(env4, v2);
+  const v6 = 10;
+  const v7 = 20;
+  const v8 = {
+    x: v6,
+    y: v7
   };
-  const v7 = v3(v6);
-  return v7;
+  const fnref9 = v5.__fn;
+  const env10 = v5.__env;
+  const v11 = fnref9(env10, v8);
+  return v11;
 }
 return main();
 ",
@@ -178,12 +196,16 @@ return main();
       let v0 = getX
       let v1 = Num
       let v2 = alloc { y: v1 }
-      let v3 = call *v0(v2)
-      let v4 = 10
-      let v5 = 20
-      let v6 = alloc { x: v4, y: v5 }
-      let v7 = call *v3(v6)
-      return v7",
+      let fnref3 = read v0.__fn
+      let env4 = read v0.__env
+      let v5 = call *fnref3(env4, v2)
+      let v6 = 10
+      let v7 = 20
+      let v8 = alloc { x: v6, y: v7 }
+      let fnref9 = read v5.__fn
+      let env10 = read v5.__env
+      let v11 = call *fnref9(env10, v8)
+      return v11",
     "name": "p1",
     "normalized": "10",
     "solverTrace": "=== Formula ===
@@ -223,17 +245,21 @@ return main();
     z: v1,
     y: v2
   };
-  const v4 = v0(v3);
-  const v5 = 5;
-  const v6 = 7;
-  const v7 = 3;
-  const v8 = {
-    x: v5,
-    z: v6,
-    y: v7
+  const fnref4 = v0.__fn;
+  const env5 = v0.__env;
+  const v6 = fnref4(env5, v3);
+  const v7 = 5;
+  const v8 = 7;
+  const v9 = 3;
+  const v10 = {
+    x: v7,
+    z: v8,
+    y: v9
   };
-  const v9 = v4(v8);
-  return v9;
+  const fnref11 = v6.__fn;
+  const env12 = v6.__env;
+  const v13 = fnref11(env12, v10);
+  return v13;
 }
 return main();
 ",
@@ -286,13 +312,17 @@ return main();
       let v1 = Num
       let v2 = Num
       let v3 = alloc { z: v1, y: v2 }
-      let v4 = call *v0(v3)
-      let v5 = 5
-      let v6 = 7
-      let v7 = 3
-      let v8 = alloc { x: v5, z: v6, y: v7 }
-      let v9 = call *v4(v8)
-      return v9",
+      let fnref4 = read v0.__fn
+      let env5 = read v0.__env
+      let v6 = call *fnref4(env5, v3)
+      let v7 = 5
+      let v8 = 7
+      let v9 = 3
+      let v10 = alloc { x: v7, z: v8, y: v9 }
+      let fnref11 = read v6.__fn
+      let env12 = read v6.__env
+      let v13 = call *fnref11(env12, v10)
+      return v13",
     "name": "p2",
     "normalized": "5",
     "solverTrace": "=== Formula ===
@@ -330,15 +360,19 @@ return main();
   const v2 = {
     name: v1
   };
-  const v3 = v0(v2);
-  const v4 = 100;
-  const v5 = "point";
-  const v6 = {
-    x: v4,
-    name: v5
+  const fnref3 = v0.__fn;
+  const env4 = v0.__env;
+  const v5 = fnref3(env4, v2);
+  const v6 = 100;
+  const v7 = "point";
+  const v8 = {
+    x: v6,
+    name: v7
   };
-  const v7 = v3(v6);
-  return v7;
+  const fnref9 = v5.__fn;
+  const env10 = v5.__env;
+  const v11 = fnref9(env10, v8);
+  return v11;
 }
 return main();
 ",
@@ -382,12 +416,16 @@ return main();
       let v0 = getX
       let v1 = String
       let v2 = alloc { name: v1 }
-      let v3 = call *v0(v2)
-      let v4 = 100
-      let v5 = "point"
-      let v6 = alloc { x: v4, name: v5 }
-      let v7 = call *v3(v6)
-      return v7",
+      let fnref3 = read v0.__fn
+      let env4 = read v0.__env
+      let v5 = call *fnref3(env4, v2)
+      let v6 = 100
+      let v7 = "point"
+      let v8 = alloc { x: v6, name: v7 }
+      let fnref9 = read v5.__fn
+      let env10 = read v5.__env
+      let v11 = call *fnref9(env10, v8)
+      return v11",
     "name": "p3",
     "normalized": "100",
     "solverTrace": "=== Formula ===
@@ -425,22 +463,32 @@ exports[`Language Tour — Row Polymorphism > polymorphic extension 1`] = `
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_24;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_24;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_25(rec) {
+function closure_25(env0, rec1) {
   const v0 = 0;
   const v1 = {
-    ...rec,
+    ...rec1,
     z: v0
   };
   return v1;
 }
 
-function closure_24(r) {
-  const v0 = closure_25;
-  return v0;
+function closure_24(env0, r1) {
+  const env_cls2 = {};
+  const fnref_cls2 = closure_25;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 return main();
 ",
@@ -513,17 +561,21 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_24
-      return v0
-  fn closure_25(rec) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_24
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_25(env0, rec1) entry=entry
     entry:
       let v0 = 0
-      let v1 = update-immutable rec { z: v0 }
+      let v1 = update-immutable rec1 { z: v0 }
       return v1
-  fn closure_24(r) entry=entry
+  fn closure_24(env0, r1) entry=entry
     entry:
-      let v0 = &closure_25
-      return v0",
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_25
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "addZ",
     "normalized": "λ(r: Row) =>
   (closure: λ(rec: Σ($sig: [ y: Num, x: Num | r ]) .
@@ -564,15 +616,19 @@ return main();
     "codegenJS": "function main() {
   const v0 = addZ;
   const v1 = {};
-  const v2 = v0(v1);
-  const v3 = 2;
-  const v4 = 1;
-  const v5 = {
-    y: v3,
-    x: v4
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  const v5 = 2;
+  const v6 = 1;
+  const v7 = {
+    y: v5,
+    x: v6
   };
-  const v6 = v2(v5);
-  return v6;
+  const fnref8 = v4.__fn;
+  const env9 = v4.__env;
+  const v10 = fnref8(env9, v7);
+  return v10;
 }
 return main();
 ",
@@ -611,12 +667,16 @@ return main();
     entry:
       let v0 = addZ
       let v1 = alloc {  }
-      let v2 = call *v0(v1)
-      let v3 = 2
-      let v4 = 1
-      let v5 = alloc { y: v3, x: v4 }
-      let v6 = call *v2(v5)
-      return v6",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      let v5 = 2
+      let v6 = 1
+      let v7 = alloc { y: v5, x: v6 }
+      let fnref8 = read v4.__fn
+      let env9 = read v4.__env
+      let v10 = call *fnref8(env9, v7)
+      return v10",
     "name": "p1",
     "normalized": "Struct [ y: 2, x: 1, z: 0 ]",
     "solverTrace": "=== Formula ===
@@ -655,17 +715,21 @@ return main();
   const v2 = {
     color: v1
   };
-  const v3 = v0(v2);
-  const v4 = 10;
-  const v5 = 5;
-  const v6 = "red";
-  const v7 = {
-    y: v4,
-    x: v5,
-    color: v6
+  const fnref3 = v0.__fn;
+  const env4 = v0.__env;
+  const v5 = fnref3(env4, v2);
+  const v6 = 10;
+  const v7 = 5;
+  const v8 = "red";
+  const v9 = {
+    y: v6,
+    x: v7,
+    color: v8
   };
-  const v8 = v3(v7);
-  return v8;
+  const fnref10 = v5.__fn;
+  const env11 = v5.__env;
+  const v12 = fnref10(env11, v9);
+  return v12;
 }
 return main();
 ",
@@ -713,13 +777,17 @@ return main();
       let v0 = addZ
       let v1 = String
       let v2 = alloc { color: v1 }
-      let v3 = call *v0(v2)
-      let v4 = 10
-      let v5 = 5
-      let v6 = "red"
-      let v7 = alloc { y: v4, x: v5, color: v6 }
-      let v8 = call *v3(v7)
-      return v8",
+      let fnref3 = read v0.__fn
+      let env4 = read v0.__env
+      let v5 = call *fnref3(env4, v2)
+      let v6 = 10
+      let v7 = 5
+      let v8 = "red"
+      let v9 = alloc { y: v6, x: v7, color: v8 }
+      let fnref10 = read v5.__fn
+      let env11 = read v5.__env
+      let v12 = call *fnref10(env11, v9)
+      return v12",
     "name": "p2",
     "normalized": "Struct [ y: 10, x: 5, color: "red", z: 0 ]",
     "solverTrace": "",
@@ -734,18 +802,28 @@ exports[`Language Tour — Row Polymorphism > polymorphic projection 1`] = `
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_19;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_19;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_20(env0, obj1) {
+  const v0 = obj1.name;
   return v0;
 }
 
-function closure_20(obj) {
-  const v0 = obj.name;
-  return v0;
-}
-
-function closure_19(r) {
-  const v0 = closure_20;
-  return v0;
+function closure_19(env0, r1) {
+  const env_cls2 = {};
+  const fnref_cls2 = closure_20;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 return main();
 ",
@@ -808,16 +886,20 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_19
-      return v0
-  fn closure_20(obj) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_19
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_20(env0, obj1) entry=entry
     entry:
-      let v0 = read obj.name
+      let v0 = read obj1.name
       return v0
-  fn closure_19(r) entry=entry
+  fn closure_19(env0, r1) entry=entry
     entry:
-      let v0 = &closure_20
-      return v0",
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_20
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "getName",
     "normalized": "λ(r: Row) =>
   (closure: λ(obj: Σ($sig: [ name: String | r ]) .
@@ -1002,10 +1084,14 @@ return main();
   const v2 = {
     age: v1
   };
-  const v3 = v0(v2);
-  const v4 = person;
-  const v5 = v3(v4);
-  return v5;
+  const fnref3 = v0.__fn;
+  const env4 = v0.__env;
+  const v5 = fnref3(env4, v2);
+  const v6 = person;
+  const fnref7 = v5.__fn;
+  const env8 = v5.__env;
+  const v9 = fnref7(env8, v6);
+  return v9;
 }
 return main();
 ",
@@ -1040,10 +1126,14 @@ return main();
       let v0 = getName
       let v1 = Num
       let v2 = alloc { age: v1 }
-      let v3 = call *v0(v2)
-      let v4 = person
-      let v5 = call *v3(v4)
-      return v5",
+      let fnref3 = read v0.__fn
+      let env4 = read v0.__env
+      let v5 = call *fnref3(env4, v2)
+      let v6 = person
+      let fnref7 = read v5.__fn
+      let env8 = read v5.__env
+      let v9 = call *fnref7(env8, v6)
+      return v9",
     "name": "n1",
     "normalized": ""Alice"",
     "solverTrace": "=== Formula ===
@@ -1083,10 +1173,14 @@ return main();
     author: v1,
     pages: v2
   };
-  const v4 = v0(v3);
-  const v5 = book;
-  const v6 = v4(v5);
-  return v6;
+  const fnref4 = v0.__fn;
+  const env5 = v0.__env;
+  const v6 = fnref4(env5, v3);
+  const v7 = book;
+  const fnref8 = v6.__fn;
+  const env9 = v6.__env;
+  const v10 = fnref8(env9, v7);
+  return v10;
 }
 return main();
 ",
@@ -1126,10 +1220,14 @@ return main();
       let v1 = String
       let v2 = Num
       let v3 = alloc { author: v1, pages: v2 }
-      let v4 = call *v0(v3)
-      let v5 = book
-      let v6 = call *v4(v5)
-      return v6",
+      let fnref4 = read v0.__fn
+      let env5 = read v0.__env
+      let v6 = call *fnref4(env5, v3)
+      let v7 = book
+      let fnref8 = read v6.__fn
+      let env9 = read v6.__env
+      let v10 = call *fnref8(env9, v7)
+      return v10",
     "name": "n2",
     "normalized": ""1984"",
     "solverTrace": "=== Formula ===

--- a/src/__tests__/integration/__snapshots__/type-constructors.test.ts.snap
+++ b/src/__tests__/integration/__snapshots__/type-constructors.test.ts.snap
@@ -4,14 +4,19 @@ exports[`Language Tour — Type Constructors > maybe type 1`] = `
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_13;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_13;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_13(a) {
+function closure_13(env0, a1) {
   const v0 = "Unit";
   const v1 = {
-    just: a,
+    just: a1,
     nothing: v0
   };
   return v1;
@@ -52,12 +57,14 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_13
-      return v0
-  fn closure_13(a) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_13
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_13(env0, a1) entry=entry
     entry:
       let v0 = Unit
-      let v1 = alloc { just: a, nothing: v0 }
+      let v1 = alloc { just: a1, nothing: v0 }
       return v1",
     "name": "Maybe",
     "normalized": "λ(a: Type) -> (closure: Variant [ just: a, nothing: Unit ] -| Γ: a)",

--- a/src/__tests__/integration/__snapshots__/typeclasses.test.ts.snap
+++ b/src/__tests__/integration/__snapshots__/typeclasses.test.ts.snap
@@ -8,11 +8,19 @@ exports[`Language Tour — Typeclasses > interfaces via records 1`] = `
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_20;
-  return v0;
+  const env_cls2 = {
+    v0: String
+  };
+  const fnref_cls2 = closure_20;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_20(String, t) {
+function closure_20(env0, t1) {
+  const cap_0 = env0.v0;
   const v0 = {};
   return v0;
 }
@@ -80,10 +88,13 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_20
-      return v0
-  fn closure_20(String, t) entry=entry
+      let env_cls2 = alloc { v0: String }
+      let fnref_cls2 = &closure_20
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_20(env0, t1) entry=entry
     entry:
+      let cap_0 = read env0.v0
       let v0 = alloc {  }
       return v0",
     "name": "Show",
@@ -120,11 +131,19 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_24;
-  return v0;
+  const env_cls2 = {
+    v0: Bool
+  };
+  const fnref_cls2 = closure_24;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_24(Bool, t) {
+function closure_24(env0, t1) {
+  const cap_0 = env0.v0;
   const v0 = {};
   return v0;
 }
@@ -212,10 +231,13 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_24
-      return v0
-  fn closure_24(Bool, t) entry=entry
+      let env_cls2 = alloc { v0: Bool }
+      let fnref_cls2 = &closure_24
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_24(env0, t1) entry=entry
     entry:
+      let cap_0 = read env0.v0
       let v0 = alloc {  }
       return v0",
     "name": "Eq",
@@ -253,16 +275,16 @@ return main();
   {
     "codegenJS": "function main() {
   const v0 = "Num";
-  const env_pap1 = {
+  const env_cls1 = {
     v0: v0
   };
-  const fnref_pap1 = pap_fn1;
-  const closure_pap1 = {
-    __fn: fnref_pap1,
-    __env: env_pap1
+  const fnref_cls1 = pap_fn1;
+  const closure_cls1 = {
+    __fn: fnref_cls1,
+    __env: env_cls1
   };
   const v2 = {
-    show: closure_pap1
+    show: closure_cls1
   };
   return v2;
 }
@@ -301,10 +323,10 @@ return main();
   fn main entry=entry
     entry:
       let v0 = Num
-      let env_pap1 = alloc { v0: v0 }
-      let fnref_pap1 = &pap_fn1
-      let closure_pap1 = alloc { __fn: fnref_pap1, __env: env_pap1 }
-      let v2 = alloc { show: closure_pap1 }
+      let env_cls1 = alloc { v0: v0 }
+      let fnref_cls1 = &pap_fn1
+      let closure_cls1 = alloc { __fn: fnref_cls1, __env: env_cls1 }
+      let v2 = alloc { show: closure_cls1 }
       return v2
   fn pap_fn1(env2, arg3) entry=pap_fn1_entry
     pap_fn1_entry:
@@ -354,14 +376,19 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_21;
-  const v1 = {
-    show: v0
+  const env_cls2 = {};
+  const fnref_cls2 = closure_21;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
   };
-  return v1;
+  const v3 = {
+    show: closure_cls2
+  };
+  return v3;
 }
 
-function closure_21(b) {
+function closure_21(env0, b1) {
   let __block = "entry";
   while (true) {
     switch (__block) {
@@ -370,11 +397,11 @@ function closure_21(b) {
         break;
       }
       case "sw1": {
-        if ((String(b) === "true")) {
+        if ((String(b1) === "true")) {
           (__block = "case3");
           break;
         }
-        if ((String(b) === "false")) {
+        if ((String(b1) === "false")) {
           (__block = "case4");
           break;
         }
@@ -453,14 +480,16 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_21
-      let v1 = alloc { show: v0 }
-      return v1
-  fn closure_21(b) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_21
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      let v3 = alloc { show: closure_cls2 }
+      return v3
+  fn closure_21(env0, b1) entry=entry
     entry:
       jump sw1
     sw1:
-      branch b { true -> case3 | false -> case4 }
+      branch b1 { true -> case3 | false -> case4 }
     case3:
       let v4 = "true"
       let match0 = v4
@@ -609,11 +638,19 @@ exports[`Language Tour — Typeclasses > multiple constraints 1`] = `
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_20;
-  return v0;
+  const env_cls2 = {
+    v0: String
+  };
+  const fnref_cls2 = closure_20;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_20(String, t) {
+function closure_20(env0, t1) {
+  const cap_0 = env0.v0;
   const v0 = {};
   return v0;
 }
@@ -681,10 +718,13 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_20
-      return v0
-  fn closure_20(String, t) entry=entry
+      let env_cls2 = alloc { v0: String }
+      let fnref_cls2 = &closure_20
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_20(env0, t1) entry=entry
     entry:
+      let cap_0 = read env0.v0
       let v0 = alloc {  }
       return v0",
     "name": "Show",
@@ -721,11 +761,19 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_24;
-  return v0;
+  const env_cls2 = {
+    v0: Bool
+  };
+  const fnref_cls2 = closure_24;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_24(Bool, t) {
+function closure_24(env0, t1) {
+  const cap_0 = env0.v0;
   const v0 = {};
   return v0;
 }
@@ -813,10 +861,13 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_24
-      return v0
-  fn closure_24(Bool, t) entry=entry
+      let env_cls2 = alloc { v0: Bool }
+      let fnref_cls2 = &closure_24
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_24(env0, t1) entry=entry
     entry:
+      let cap_0 = read env0.v0
       let v0 = alloc {  }
       return v0",
     "name": "Eq",
@@ -854,16 +905,16 @@ return main();
   {
     "codegenJS": "function main() {
   const v0 = "Num";
-  const env_pap1 = {
+  const env_cls1 = {
     v0: v0
   };
-  const fnref_pap1 = pap_fn1;
-  const closure_pap1 = {
-    __fn: fnref_pap1,
-    __env: env_pap1
+  const fnref_cls1 = pap_fn1;
+  const closure_cls1 = {
+    __fn: fnref_cls1,
+    __env: env_cls1
   };
   const v2 = {
-    show: closure_pap1
+    show: closure_cls1
   };
   return v2;
 }
@@ -902,10 +953,10 @@ return main();
   fn main entry=entry
     entry:
       let v0 = Num
-      let env_pap1 = alloc { v0: v0 }
-      let fnref_pap1 = &pap_fn1
-      let closure_pap1 = alloc { __fn: fnref_pap1, __env: env_pap1 }
-      let v2 = alloc { show: closure_pap1 }
+      let env_cls1 = alloc { v0: v0 }
+      let fnref_cls1 = &pap_fn1
+      let closure_cls1 = alloc { __fn: fnref_cls1, __env: env_cls1 }
+      let v2 = alloc { show: closure_cls1 }
       return v2
   fn pap_fn1(env2, arg3) entry=pap_fn1_entry
     pap_fn1_entry:
@@ -1037,7 +1088,128 @@ return main();
     "validity": "valid",
   },
   {
-    "codegenJS": "",
+    "codegenJS": "function main() {
+  const env_cls2 = {};
+  const fnref_cls2 = closure_71;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_75(env0, y1) {
+  let __block = "entry";
+  while (true) {
+    switch (__block) {
+      case "entry": {
+        const cap_0 = env0.v0;
+        const cap_1 = env0.v1;
+        const cap_2 = env0.v2;
+        (__block = "sw8");
+        break;
+      }
+      case "sw8": {
+        const v0 = cap_0.eq;
+        const fnref1 = v0.__fn;
+        const env2 = v0.__env;
+        const v3 = fnref1(env2, cap_1);
+        const fnref4 = v3.__fn;
+        const env5 = v3.__env;
+        const v6 = fnref4(env5, y1);
+        if ((String(v6) === "true")) {
+          (__block = "case10");
+          break;
+        }
+        if ((String(v6) === "false")) {
+          (__block = "case11");
+          break;
+        }
+      }
+      case "case10": {
+        const v11 = "Equal: ";
+        const v12 = cap_2.show;
+        const fnref13 = v12.__fn;
+        const env14 = v12.__env;
+        const v15 = fnref13(env14, cap_1);
+        const v16 = (v11 + v15);
+        const match7 = v16;
+        (__block = "join9");
+        break;
+      }
+      case "case11": {
+        const v12 = "Not equal";
+        const match7 = v12;
+        (__block = "join9");
+        break;
+      }
+      case "join9": {
+        return match7;
+      }
+    }
+  }
+}
+
+function closure_74(env0, x1) {
+  const cap_0 = env0.v0;
+  const cap_1 = env0.v1;
+  const cap_2 = env0.v2;
+  const env_cls2 = {
+    v0: cap_1,
+    v1: x1,
+    v2: cap_2
+  };
+  const fnref_cls2 = closure_75;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_73(env0, eq1) {
+  const cap_0 = env0.v0;
+  const cap_1 = env0.v1;
+  const env_cls2 = {
+    v0: cap_0,
+    v1: eq1,
+    v2: cap_1
+  };
+  const fnref_cls2 = closure_74;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_72(env0, show1) {
+  const cap_0 = env0.v0;
+  const env_cls2 = {
+    v0: cap_0,
+    v1: show1
+  };
+  const fnref_cls2 = closure_73;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_71(env0, t1) {
+  const env_cls2 = {
+    v0: t1
+  };
+  const fnref_cls2 = closure_72;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+return main();
+",
     "elaborated": "λ(t: Type) =>
   λ(show: Σ($sig: [ show: Π(t3: t) -> String ]) .
     Schema [ show: Π(t3: t) -> String ]) =>
@@ -1048,7 +1220,6 @@ return main();
           match ((eq).eq) x y
             | true -> FFI.$concat "Equal: " (((show).show) x)
             | false -> "Not equal"",
-    "error": "Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures",
     "gram": "[1] root
   :entry -> [3]
 [2] stmt:let {"variable":"displayIfEqual"}
@@ -1299,7 +1470,73 @@ return main();
         (= x x)
         (= y y)))))",
     "kind": "let",
-    "mir": "",
+    "mir": "module
+  fn main entry=entry
+    entry:
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_71
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_75(env0, y1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let cap_1 = read env0.v1
+      let cap_2 = read env0.v2
+      jump sw8
+    sw8:
+      let v0 = read cap_0.eq
+      let fnref1 = read v0.__fn
+      let env2 = read v0.__env
+      let v3 = call *fnref1(env2, cap_1)
+      let fnref4 = read v3.__fn
+      let env5 = read v3.__env
+      let v6 = call *fnref4(env5, y1)
+      branch v6 { true -> case10 | false -> case11 }
+    case10:
+      let v11 = "Equal: "
+      let v12 = read cap_2.show
+      let fnref13 = read v12.__fn
+      let env14 = read v12.__env
+      let v15 = call *fnref13(env14, cap_1)
+      let v16 = ++(v11, v15)
+      let match7 = v16
+      jump join9
+    case11:
+      let v12 = "Not equal"
+      let match7 = v12
+      jump join9
+    join9:
+      return match7
+  fn closure_74(env0, x1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let cap_1 = read env0.v1
+      let cap_2 = read env0.v2
+      let env_cls2 = alloc { v0: cap_1, v1: x1, v2: cap_2 }
+      let fnref_cls2 = &closure_75
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_73(env0, eq1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let cap_1 = read env0.v1
+      let env_cls2 = alloc { v0: cap_0, v1: eq1, v2: cap_1 }
+      let fnref_cls2 = &closure_74
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_72(env0, show1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let env_cls2 = alloc { v0: cap_0, v1: show1 }
+      let fnref_cls2 = &closure_73
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_71(env0, t1) entry=entry
+    entry:
+      let env_cls2 = alloc { v0: t1 }
+      let fnref_cls2 = &closure_72
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "displayIfEqual",
     "normalized": "λ(t: Type) =>
   (closure: λ(show: Σ($sig: [ show: Π(t3: t) -> String ]) .
@@ -1391,16 +1628,26 @@ return main();
     "codegenJS": "function main() {
   const v0 = displayIfEqual;
   const v1 = "Num";
-  const v2 = v0(v1);
-  const v3 = ShowNum;
-  const v4 = v2(v3);
-  const v5 = EqNum;
-  const v6 = v4(v5);
-  const v7 = 5;
-  const v8 = v6(v7);
-  const v9 = 5;
-  const v10 = v8(v9);
-  return v10;
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  const v5 = ShowNum;
+  const fnref6 = v4.__fn;
+  const env7 = v4.__env;
+  const v8 = fnref6(env7, v5);
+  const v9 = EqNum;
+  const fnref10 = v8.__fn;
+  const env11 = v8.__env;
+  const v12 = fnref10(env11, v9);
+  const v13 = 5;
+  const fnref14 = v12.__fn;
+  const env15 = v12.__env;
+  const v16 = fnref14(env15, v13);
+  const v17 = 5;
+  const fnref18 = v16.__fn;
+  const env19 = v16.__env;
+  const v20 = fnref18(env19, v17);
+  return v20;
 }
 return main();
 ",
@@ -1445,16 +1692,26 @@ return main();
     entry:
       let v0 = displayIfEqual
       let v1 = Num
-      let v2 = call *v0(v1)
-      let v3 = ShowNum
-      let v4 = call *v2(v3)
-      let v5 = EqNum
-      let v6 = call *v4(v5)
-      let v7 = 5
-      let v8 = call *v6(v7)
-      let v9 = 5
-      let v10 = call *v8(v9)
-      return v10",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      let v5 = ShowNum
+      let fnref6 = read v4.__fn
+      let env7 = read v4.__env
+      let v8 = call *fnref6(env7, v5)
+      let v9 = EqNum
+      let fnref10 = read v8.__fn
+      let env11 = read v8.__env
+      let v12 = call *fnref10(env11, v9)
+      let v13 = 5
+      let fnref14 = read v12.__fn
+      let env15 = read v12.__env
+      let v16 = call *fnref14(env15, v13)
+      let v17 = 5
+      let fnref18 = read v16.__fn
+      let env19 = read v16.__env
+      let v20 = call *fnref18(env19, v17)
+      return v20",
     "name": "msg",
     "normalized": "($concat: ("Equal: ") ((stringify: (Num) (5))))",
     "solverTrace": "=== Formula ===
@@ -1496,11 +1753,19 @@ exports[`Language Tour — Typeclasses > traits with implicits 1`] = `
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_20;
-  return v0;
+  const env_cls2 = {
+    v0: String
+  };
+  const fnref_cls2 = closure_20;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_20(String, t) {
+function closure_20(env0, t1) {
+  const cap_0 = env0.v0;
   const v0 = {};
   return v0;
 }
@@ -1568,10 +1833,13 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_20
-      return v0
-  fn closure_20(String, t) entry=entry
+      let env_cls2 = alloc { v0: String }
+      let fnref_cls2 = &closure_20
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_20(env0, t1) entry=entry
     entry:
+      let cap_0 = read env0.v0
       let v0 = alloc {  }
       return v0",
     "name": "Show",
@@ -1608,11 +1876,19 @@ return main();
   },
   {
     "codegenJS": "function main() {
-  const v0 = closure_24;
-  return v0;
+  const env_cls2 = {
+    v0: Bool
+  };
+  const fnref_cls2 = closure_24;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_24(Bool, t) {
+function closure_24(env0, t1) {
+  const cap_0 = env0.v0;
   const v0 = {};
   return v0;
 }
@@ -1700,10 +1976,13 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_24
-      return v0
-  fn closure_24(Bool, t) entry=entry
+      let env_cls2 = alloc { v0: Bool }
+      let fnref_cls2 = &closure_24
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_24(env0, t1) entry=entry
     entry:
+      let cap_0 = read env0.v0
       let v0 = alloc {  }
       return v0",
     "name": "Eq",
@@ -1741,16 +2020,16 @@ return main();
   {
     "codegenJS": "function main() {
   const v0 = "Num";
-  const env_pap1 = {
+  const env_cls1 = {
     v0: v0
   };
-  const fnref_pap1 = pap_fn1;
-  const closure_pap1 = {
-    __fn: fnref_pap1,
-    __env: env_pap1
+  const fnref_cls1 = pap_fn1;
+  const closure_cls1 = {
+    __fn: fnref_cls1,
+    __env: env_cls1
   };
   const v2 = {
-    show: closure_pap1
+    show: closure_cls1
   };
   return v2;
 }
@@ -1789,10 +2068,10 @@ return main();
   fn main entry=entry
     entry:
       let v0 = Num
-      let env_pap1 = alloc { v0: v0 }
-      let fnref_pap1 = &pap_fn1
-      let closure_pap1 = alloc { __fn: fnref_pap1, __env: env_pap1 }
-      let v2 = alloc { show: closure_pap1 }
+      let env_cls1 = alloc { v0: v0 }
+      let fnref_cls1 = &pap_fn1
+      let closure_cls1 = alloc { __fn: fnref_cls1, __env: env_cls1 }
+      let v2 = alloc { show: closure_cls1 }
       return v2
   fn pap_fn1(env2, arg3) entry=pap_fn1_entry
     pap_fn1_entry:
@@ -1924,12 +2203,39 @@ return main();
     "validity": "valid",
   },
   {
-    "codegenJS": "",
+    "codegenJS": "function main() {
+  const env_cls2 = {};
+  const fnref_cls2 = closure_27;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_28(env0, show1) {
+  const cap_0 = env0.v0;
+  const v0 = show1.show;
+  return v0;
+}
+
+function closure_27(env0, t1) {
+  const env_cls2 = {
+    v0: t1
+  };
+  const fnref_cls2 = closure_28;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+return main();
+",
     "elaborated": "λ(t: Type) =>
   λ(show: Σ($sig: [ show: Π(t3: t) -> String ]) .
     Schema [ show: Π(t3: t) -> String ]) =>
     λ(x: t) -> ((show).show) x",
-    "error": "Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures",
     "gram": "[1] root
   :entry -> [3]
 [2] stmt:let {"variable":"display"}
@@ -1997,7 +2303,24 @@ return main();
   :env -> [26]",
     "ivl": "(forall ((t Type)) (forall ((x Type)) (= x x)))",
     "kind": "let",
-    "mir": "",
+    "mir": "module
+  fn main entry=entry
+    entry:
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_27
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_28(env0, show1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let v0 = read show1.show
+      return v0
+  fn closure_27(env0, t1) entry=entry
+    entry:
+      let env_cls2 = alloc { v0: t1 }
+      let fnref_cls2 = &closure_28
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "display",
     "normalized": "λ(t: Type) =>
   (closure: λ(show: Σ($sig: [ show: Π(t3: t) -> String ]) .
@@ -2047,12 +2370,39 @@ return main();
     "validity": "valid",
   },
   {
-    "codegenJS": "",
+    "codegenJS": "function main() {
+  const env_cls2 = {};
+  const fnref_cls2 = closure_35;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+
+function closure_36(env0, eq1) {
+  const cap_0 = env0.v0;
+  const v0 = eq1.eq;
+  return v0;
+}
+
+function closure_35(env0, t1) {
+  const env_cls2 = {
+    v0: t1
+  };
+  const fnref_cls2 = closure_36;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
+}
+return main();
+",
     "elaborated": "λ(t: Type) =>
   λ(eq: Σ($sig: [ eq: Π(t5: t) -> Π(t6: t) -> Bool ]) .
     Schema [ eq: Π(t5: t) -> Π(t6: t) -> Bool ]) =>
     λ(x: t) -> λ(y: t) -> ((eq).eq) x y",
-    "error": "Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures; Bridge: closure capture not yet implemented for curried returns — nested closures reference outer captures",
     "gram": "[1] root
   :entry -> [3]
 [2] stmt:let {"variable":"areEqual"}
@@ -2143,7 +2493,24 @@ return main();
     "ivl": "(forall ((t Type))
   (forall ((x Type)) (forall ((y Type)) (and (= x x) (= y y)))))",
     "kind": "let",
-    "mir": "",
+    "mir": "module
+  fn main entry=entry
+    entry:
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_35
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_36(env0, eq1) entry=entry
+    entry:
+      let cap_0 = read env0.v0
+      let v0 = read eq1.eq
+      return v0
+  fn closure_35(env0, t1) entry=entry
+    entry:
+      let env_cls2 = alloc { v0: t1 }
+      let fnref_cls2 = &closure_36
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2",
     "name": "areEqual",
     "normalized": "λ(t: Type) =>
   (closure: λ(eq: Σ($sig: [ eq: Π(t5: t) -> Π(t6: t) -> Bool ]) .
@@ -2209,12 +2576,18 @@ return main();
     "codegenJS": "function main() {
   const v0 = display;
   const v1 = "Num";
-  const v2 = v0(v1);
-  const v3 = ShowNum;
-  const v4 = v2(v3);
-  const v5 = 42;
-  const v6 = v4(v5);
-  return v6;
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  const v5 = ShowNum;
+  const fnref6 = v4.__fn;
+  const env7 = v4.__env;
+  const v8 = fnref6(env7, v5);
+  const v9 = 42;
+  const fnref10 = v8.__fn;
+  const env11 = v8.__env;
+  const v12 = fnref10(env11, v9);
+  return v12;
 }
 return main();
 ",
@@ -2248,12 +2621,18 @@ return main();
     entry:
       let v0 = display
       let v1 = Num
-      let v2 = call *v0(v1)
-      let v3 = ShowNum
-      let v4 = call *v2(v3)
-      let v5 = 42
-      let v6 = call *v4(v5)
-      return v6",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      let v5 = ShowNum
+      let fnref6 = read v4.__fn
+      let env7 = read v4.__env
+      let v8 = call *fnref6(env7, v5)
+      let v9 = 42
+      let fnref10 = read v8.__fn
+      let env11 = read v8.__env
+      let v12 = call *fnref10(env11, v9)
+      return v12",
     "name": "shown",
     "normalized": "(stringify: (Num) (42))",
     "solverTrace": "=== Formula ===
@@ -2288,14 +2667,22 @@ return main();
     "codegenJS": "function main() {
   const v0 = areEqual;
   const v1 = "Num";
-  const v2 = v0(v1);
-  const v3 = EqNum;
-  const v4 = v2(v3);
-  const v5 = 10;
-  const v6 = v4(v5);
-  const v7 = 10;
-  const v8 = v6(v7);
-  return v8;
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  const v5 = EqNum;
+  const fnref6 = v4.__fn;
+  const env7 = v4.__env;
+  const v8 = fnref6(env7, v5);
+  const v9 = 10;
+  const fnref10 = v8.__fn;
+  const env11 = v8.__env;
+  const v12 = fnref10(env11, v9);
+  const v13 = 10;
+  const fnref14 = v12.__fn;
+  const env15 = v12.__env;
+  const v16 = fnref14(env15, v13);
+  return v16;
 }
 return main();
 ",
@@ -2333,14 +2720,22 @@ return main();
     entry:
       let v0 = areEqual
       let v1 = Num
-      let v2 = call *v0(v1)
-      let v3 = EqNum
-      let v4 = call *v2(v3)
-      let v5 = 10
-      let v6 = call *v4(v5)
-      let v7 = 10
-      let v8 = call *v6(v7)
-      return v8",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      let v5 = EqNum
+      let fnref6 = read v4.__fn
+      let env7 = read v4.__env
+      let v8 = call *fnref6(env7, v5)
+      let v9 = 10
+      let fnref10 = read v8.__fn
+      let env11 = read v8.__env
+      let v12 = call *fnref10(env11, v9)
+      let v13 = 10
+      let fnref14 = read v12.__fn
+      let env15 = read v12.__env
+      let v16 = call *fnref14(env15, v13)
+      return v16",
     "name": "same",
     "normalized": "true",
     "solverTrace": "=== Formula ===

--- a/src/__tests__/integration/__snapshots__/types.test.ts.snap
+++ b/src/__tests__/integration/__snapshots__/types.test.ts.snap
@@ -4,35 +4,45 @@ exports[`Language Tour — Defining Types > computing types 1`] = `
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_19;
-  return v0;
+  const env_cls2 = {
+    v0: Num,
+    v1: String
+  };
+  const fnref_cls2 = closure_19;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_19(Num, String, b) {
+function closure_19(env0, b1) {
   let __block = "entry";
   while (true) {
     switch (__block) {
       case "entry": {
+        const cap_0 = env0.v0;
+        const cap_1 = env0.v1;
         (__block = "sw1");
         break;
       }
       case "sw1": {
-        if ((String(b) === "true")) {
+        if ((String(b1) === "true")) {
           (__block = "case3");
           break;
         }
-        if ((String(b) === "false")) {
+        if ((String(b1) === "false")) {
           (__block = "case4");
           break;
         }
       }
       case "case3": {
-        const match0 = Num;
+        const match0 = cap_0;
         (__block = "join2");
         break;
       }
       case "case4": {
-        const match0 = String;
+        const match0 = cap_1;
         (__block = "join2");
         break;
       }
@@ -100,18 +110,22 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_19
-      return v0
-  fn closure_19(Num, String, b) entry=entry
+      let env_cls2 = alloc { v0: Num, v1: String }
+      let fnref_cls2 = &closure_19
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_19(env0, b1) entry=entry
     entry:
+      let cap_0 = read env0.v0
+      let cap_1 = read env0.v1
       jump sw1
     sw1:
-      branch b { true -> case3 | false -> case4 }
+      branch b1 { true -> case3 | false -> case4 }
     case3:
-      let match0 = Num
+      let match0 = cap_0
       jump join2
     case4:
-      let match0 = String
+      let match0 = cap_1
       jump join2
     join2:
       return match0",
@@ -160,8 +174,10 @@ return main();
     "codegenJS": "function main() {
   const v0 = chooseType;
   const v1 = true;
-  const v2 = v0(v1);
-  return v2;
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  return v4;
 }
 return main();
 ",
@@ -184,8 +200,10 @@ return main();
     entry:
       let v0 = chooseType
       let v1 = true
-      let v2 = call *v0(v1)
-      return v2",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      return v4",
     "name": "T1",
     "normalized": "Num",
     "solverTrace": "=== Formula ===
@@ -220,8 +238,10 @@ return main();
     "codegenJS": "function main() {
   const v0 = chooseType;
   const v1 = false;
-  const v2 = v0(v1);
-  return v2;
+  const fnref2 = v0.__fn;
+  const env3 = v0.__env;
+  const v4 = fnref2(env3, v1);
+  return v4;
 }
 return main();
 ",
@@ -244,8 +264,10 @@ return main();
     entry:
       let v0 = chooseType
       let v1 = false
-      let v2 = call *v0(v1)
-      return v2",
+      let fnref2 = read v0.__fn
+      let env3 = read v0.__env
+      let v4 = call *fnref2(env3, v1)
+      return v4",
     "name": "T2",
     "normalized": "String",
     "solverTrace": "=== Formula ===

--- a/src/__tests__/integration/__snapshots__/variants.test.ts.snap
+++ b/src/__tests__/integration/__snapshots__/variants.test.ts.snap
@@ -278,11 +278,16 @@ exports[`Language Tour — Pattern Matching > literal patterns 1`] = `
 [
   {
     "codegenJS": "function main() {
-  const v0 = closure_17;
-  return v0;
+  const env_cls2 = {};
+  const fnref_cls2 = closure_17;
+  const closure_cls2 = {
+    __fn: fnref_cls2,
+    __env: env_cls2
+  };
+  return closure_cls2;
 }
 
-function closure_17(n) {
+function closure_17(env0, n1) {
   let __block = "entry";
   while (true) {
     switch (__block) {
@@ -291,7 +296,7 @@ function closure_17(n) {
         break;
       }
       case "sw1": {
-        if ((String(n) === "0")) {
+        if ((String(n1) === "0")) {
           (__block = "case3");
           break;
         }
@@ -364,13 +369,15 @@ return main();
     "mir": "module
   fn main entry=entry
     entry:
-      let v0 = &closure_17
-      return v0
-  fn closure_17(n) entry=entry
+      let env_cls2 = alloc {  }
+      let fnref_cls2 = &closure_17
+      let closure_cls2 = alloc { __fn: fnref_cls2, __env: env_cls2 }
+      return closure_cls2
+  fn closure_17(env0, n1) entry=entry
     entry:
       jump sw1
     sw1:
-      branch n { 0 -> case3; default -> default4 }
+      branch n1 { 0 -> case3; default -> default4 }
     case3:
       let v4 = true
       let match0 = v4

--- a/src/lowering/interpret.ts
+++ b/src/lowering/interpret.ts
@@ -1,22 +1,8 @@
-import { match } from "ts-pattern";
+import { match, P } from "ts-pattern";
 import type { Module, Function, Block, Instr, Expr, Terminator, Label } from "./mir";
 import type { Literal } from "@yap/shared/literals";
 
 export type Value = null | number | boolean | string | { [k: string]: Value } | { __funcref: string };
-
-const isRecord = (v: Value): v is { [k: string]: Value } => typeof v === "object" && v !== null && !("__funcref" in v);
-
-const fnRefName = (v: Value): string =>
-	match(v)
-		.when(isRecord, r => {
-			const fn = r.__fn;
-			return fn !== undefined && typeof fn === "object" && fn !== null && "__funcref" in fn ? String((fn as { __funcref: string }).__funcref) : "";
-		})
-		.when(
-			(x): x is { __funcref: string } => typeof x === "object" && x !== null && "__funcref" in x,
-			r => r.__funcref,
-		)
-		.otherwise(() => "");
 
 type Env = Map<string, Value>;
 
@@ -131,7 +117,9 @@ const execInstr = (env: Env, instr: Instr, ctx: Ctx): void => {
 					env.set(result, fn(...resolvedArgs));
 				})
 				.with({ type: "indirect" }, ({ callee }) => {
-					const name = fnRefName(lkp(callee));
+					const name = match(lkp(callee))
+						.with({ __funcref: P.string }, ({ __funcref }) => __funcref)
+						.otherwise(() => "");
 
 					if (!name) {
 						throw new Error(`interpret: indirect call callee is not a function reference`);

--- a/src/lowering/interpret.ts
+++ b/src/lowering/interpret.ts
@@ -4,6 +4,20 @@ import type { Literal } from "@yap/shared/literals";
 
 export type Value = null | number | boolean | string | { [k: string]: Value } | { __funcref: string };
 
+const isRecord = (v: Value): v is { [k: string]: Value } => typeof v === "object" && v !== null && !("__funcref" in v);
+
+const fnRefName = (v: Value): string =>
+	match(v)
+		.when(isRecord, r => {
+			const fn = r.__fn;
+			return fn !== undefined && typeof fn === "object" && fn !== null && "__funcref" in fn ? String((fn as { __funcref: string }).__funcref) : "";
+		})
+		.when(
+			(x): x is { __funcref: string } => typeof x === "object" && x !== null && "__funcref" in x,
+			r => r.__funcref,
+		)
+		.otherwise(() => "");
+
 type Env = Map<string, Value>;
 
 type Ctx = {
@@ -117,11 +131,15 @@ const execInstr = (env: Env, instr: Instr, ctx: Ctx): void => {
 					env.set(result, fn(...resolvedArgs));
 				})
 				.with({ type: "indirect" }, ({ callee }) => {
-					const ref = lkp(callee) as { __funcref: string };
-					const fn = ctx.functions.get(ref.__funcref);
+					const name = fnRefName(lkp(callee));
+
+					if (!name) {
+						throw new Error(`interpret: indirect call callee is not a function reference`);
+					}
+					const fn = ctx.functions.get(name);
 
 					if (!fn) {
-						throw new Error(`interpret: unknown function "${ref.__funcref}"`);
+						throw new Error(`interpret: unknown function "${name}"`);
 					}
 					env.set(result, execFunction(fn, resolvedArgs, ctx));
 				})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes bridge closure capture for curried returns by adopting the same `{ __fn, __env }` calling convention as legacy `lowerToMir` and the PAP path.

## Changes

- **`src/GRAM/bridge/bundle.ts`**: shared `Closure.read` / `Closure.bundle` / `Closure.emit` (imported as `Closure` namespace from `bundle.ts` to avoid `Closure.closure` stutter in `closures.ts`)
- **`src/GRAM/bridge/closures.ts`**: `[env, formal]` MIR functions + bundle at use/return sites
- **`src/GRAM/bridge/emit.ts`**: application reads `__fn`/`__env`, indirect call with `[env, arg]`
- **`src/GRAM/bridge/pap.ts`**: deduped via `bundle.ts`
- **`src/lowering/interpret.ts`**: indirect callee resolves `{ __funcref }` only (bridge always passes post-`Read __fn` ref)

## Verification

- `pnpm test src/GRAM/__tests__/bridge.test.ts` — all pass (incl. curried closures + shift/reset)
- `pnpm test src/__tests__/integration/functions.test.ts` — pass

## Follow-ups

- Update remaining integration snapshots (polymorphism, typeclasses, etc.)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59d6d7ef-116a-48a8-a426-36fd4a3b51aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59d6d7ef-116a-48a8-a426-36fd4a3b51aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

